### PR TITLE
Fix DateTime calculation when saving Excel

### DIFF
--- a/dual_monitor.py
+++ b/dual_monitor.py
@@ -591,6 +591,8 @@ class UnifiedMonitor(ttk.Frame):
             with self.tc_lock: fl=self.tc_df.copy().reset_index(drop=True)
 
         # relative-minute column
+        cl["Time"] = pd.to_datetime(cl["Time"], errors="coerce")
+        fl["Time"] = pd.to_datetime(fl["Time"], errors="coerce")
         ref=self.stress_start if self.stress_start else cl["Time"].iloc[0]
         cl["rel_min"]=cl["Time"].sub(ref).dt.total_seconds().div(60)
         fl["rel_min"]=fl["Time"].sub(ref).dt.total_seconds().div(60)


### PR DESCRIPTION
## Summary
- convert Time columns to datetime before computing relative minutes

## Testing
- `python dual_monitor.py --help | head`
- `python -m py_compile immersionmonitor/dual_monitor.py`

------
https://chatgpt.com/codex/tasks/task_e_6867c5e69ad08326be39dfe771fcefa5