### PR TITLE
Fix fluid data columns in Excel export

### DIFF
--- a/dual_monitor.py
+++ b/dual_monitor.py
@@ -564,19 +564,25 @@ class UnifiedMonitor(ttk.Frame):
             return df
         if keep is None:
             keep = []
+
         if "rel_min" in df.columns:
             bucket = 1 / max(POINTS_PER_MIN, 1)
-            g = df.groupby((df["rel_min"] // bucket).astype(int))
+            df = df.assign(_bucket=(df["rel_min"] // bucket).astype(int))
         else:
             n = len(df)
             k = max(1, n // AVG_BUCKET)
-            g = df.groupby(df.index // k)
-        avg = g[cols].mean().reset_index(drop=True)
-        keep_cols = [c for c in keep + ["Time"] if c in df.columns]
-        if keep_cols:
-            keep_df = g[keep_cols].first().reset_index(drop=True)
-            avg = avg.join(keep_df)
-        return avg
+            df = df.assign(_bucket=(df.index // k))
+
+        g_cols = ["_bucket"] + [c for c in keep if c in df.columns]
+        g = df.groupby(g_cols)
+
+        agg = {c: "mean" for c in cols if c in df.columns}
+        if "Time" in df.columns:
+            agg["Time"] = "first"
+
+        out = g.agg(agg).reset_index()
+        out.pop("_bucket", None)
+        return out
     def _write_excel(self, tag):
         if not self.logging: return
         try: import xlsxwriter


### PR DESCRIPTION
## Summary
- ensure `_avg_df` groups by channel to keep all fluid readings

## Testing
- `python3 -m py_compile dual_monitor.py`

------
https://chatgpt.com/codex/tasks/task_e_6867e735d0c083268e829ee3d98bc2e8