### PR TITLE
Add worker-agent discovery for disposable bench Pis

### DIFF
--- a/AGENT_SETUP.md
+++ b/AGENT_SETUP.md
@@ -1,0 +1,55 @@
+# Worker agent setup
+
+This repository now supports a worker-agent mode. The head Pi can still use `/home/motul/nodes_ips` and SSH, but it can also discover worker Pis running `worker_agent.py`.
+
+## Target network
+
+Recommended bench network:
+
+```text
+Head Pi bench IP: 10.50.0.1
+Worker DHCP range: 10.50.0.100 to 10.50.0.200
+Worker agent port: 8765
+Discovery CIDR: 10.50.0.0/24
+```
+
+## Worker Pi image
+
+Install the runtime tools:
+
+```bash
+sudo apt update
+sudo apt install -y python3 stress-ng
+sudo mkdir -p /opt/immersionmonitor
+sudo cp worker_agent.py /opt/immersionmonitor/worker_agent.py
+sudo cp systemd/bench-worker-agent.service /etc/systemd/system/bench-worker-agent.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now bench-worker-agent.service
+```
+
+Check from the worker itself:
+
+```bash
+curl http://127.0.0.1:8765/status
+```
+
+## Head Pi usage
+
+Run the dashboard with worker discovery enabled:
+
+```bash
+python3 dual_monitor.py --discovery-cidr 10.50.0.0/24 --agent-port 8765
+```
+
+If `/home/motul/nodes_ips` exists, those SSH nodes are still used as fallback nodes. If the file is missing but `--discovery-cidr` is supplied, the dashboard relies on discovered worker agents instead.
+
+## Worker API
+
+```text
+GET  /status
+POST /stress/start
+POST /stress/stop
+POST /reboot
+```
+
+`/status` returns serial number, hostname, CPU temperature, CPU clock, CPU usage, stress state, and uptime.

--- a/AGENT_SETUP.md
+++ b/AGENT_SETUP.md
@@ -13,9 +13,40 @@ Worker agent port: 8765
 Discovery CIDR: 10.50.0.0/24
 ```
 
-## Worker Pi image
+## Fresh worker Pi workflow
 
-Install the runtime tools:
+Install **Raspberry Pi OS Lite 64-bit**, boot the worker, give it temporary internet access, then run this one-command installer:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ramorimdias/immersionmonitor/main/scripts/install_worker.sh | bash
+```
+
+Until this PR is merged, test the installer from this branch with:
+
+```bash
+IMMERSIONMONITOR_BRANCH=codex/worker-agent-discovery \
+  bash -c "$(curl -fsSL https://raw.githubusercontent.com/ramorimdias/immersionmonitor/codex/worker-agent-discovery/scripts/install_worker.sh)"
+```
+
+The installer performs these steps automatically:
+
+```text
+apt update
+install python3, stress-ng, curl, ca-certificates
+copy worker_agent.py to /opt/immersionmonitor
+install bench-worker-agent.service
+start and enable the service at boot
+```
+
+After installation, connect the worker Pi to the bench switch. The head Pi should discover it if the dashboard is started with the correct discovery CIDR.
+
+Check from the worker itself:
+
+```bash
+curl http://127.0.0.1:8765/status
+```
+
+## Manual worker installation
 
 ```bash
 sudo apt update
@@ -25,12 +56,6 @@ sudo cp worker_agent.py /opt/immersionmonitor/worker_agent.py
 sudo cp systemd/bench-worker-agent.service /etc/systemd/system/bench-worker-agent.service
 sudo systemctl daemon-reload
 sudo systemctl enable --now bench-worker-agent.service
-```
-
-Check from the worker itself:
-
-```bash
-curl http://127.0.0.1:8765/status
 ```
 
 ## Head Pi usage

--- a/dual_monitor.py
+++ b/dual_monitor.py
@@ -2,14 +2,16 @@
 """Cluster monitoring dashboard.
 
 This script collects SoC and fluid temperatures from a cluster of
-Raspberry Pis using SSH and an optional MCC-134 board. It can display a
-Tkinter GUI or run headless and periodically save data to CSV files and
-Excel workbooks.
+Raspberry Pis using worker agents, SSH fallback, and an optional MCC-134
+board. It can display a Tkinter GUI or run headless and periodically save
+data to CSV files and Excel workbooks.
 """
 
 # ───────── DEFAULT SETTINGS ─────────
-DEFAULT_NODES_FILE = "/home/motul/nodes_ips"  # ip [slots=N]
+DEFAULT_NODES_FILE = "/home/motul/nodes_ips"  # optional SSH fallback: ip [slots=N]
 DEFAULT_CSV_DIR    = "/home/motul/temperatures"
+DEFAULT_AGENT_PORT = 8765
+DEFAULT_DISCOVERY_CIDR = ""  # example: 10.50.0.0/24
 FIGSIZE      = (15, 10)
 RIGHT_MARGIN = 0.75                             # legend area
 LEGEND_ANCHOR= (0.99, 1.05)
@@ -31,11 +33,16 @@ import contextlib
 import subprocess
 import shutil
 import math
+import json
+import ipaddress
+import urllib.error
+import urllib.request
 from datetime import datetime, timedelta
 from threading  import Thread, Lock, Event
 from pathlib    import Path
 from collections import deque
 from dataclasses import dataclass
+from concurrent.futures import ThreadPoolExecutor, as_completed
 import argparse
 import logging
 import pandas as pd
@@ -56,6 +63,22 @@ from daqhats import mcc134, HatIDs, hat_list, TcTypes
 CSV_DIR: Path
 RAW_SOC: Path
 RAW_FLUID: Path
+AGENT_PORT: int
+DISCOVERY_CIDR: str
+
+
+@dataclass
+class WorkerInfo:
+    """Runtime identity for one worker node."""
+
+    ip: str
+    node_id: str
+    hostname: str = ""
+    source: str = "ssh"
+
+    @property
+    def label(self) -> str:
+        return self.hostname or self.node_id or self.ip
 
 
 class DataWriter:
@@ -125,9 +148,12 @@ class UnifiedMonitor(ttk.Frame):
             ttk.Style(master).configure(".", font=BIG_FONT, padding=6)
 
         # live data
-        self.cl_lock=Lock(); self.tc_lock=Lock()
-        self.cl_df=pd.DataFrame(columns=["Time","Node","Temp","Clock"])
+        self.cl_lock=Lock(); self.tc_lock=Lock(); self.nodes_lock=Lock()
+        self.cl_df=pd.DataFrame(columns=["Time","Node","Temp","Clock","Usage"])
         self.tc_df=pd.DataFrame(columns=["Time","Channel","Temp"])
+        self.node_ips: list[str] = []
+        self.worker_info: dict[str, WorkerInfo] = {}
+        self.polling_nodes: set[str] = set()
 
         # state flags
         self.stop=Event(); self.alive=True
@@ -144,17 +170,20 @@ class UnifiedMonitor(ttk.Frame):
 
         if not self.headless:
             self._build_ui()
-        self.local_ip=socket.gethostbyname(socket.gethostname())
-        self.node_ips=self._load_nodes(); self._show_connection_status()
+        self.local_ip = self._get_local_ip()
 
-        # workers
-        for ip in self.node_ips:
-            Thread(target=self._poll_node, args=(ip,), daemon=True).start()
-        self.hat = self._init_hat()
-        Thread(target=self._tc_worker, daemon=True).start()
-
+        # File writers must exist before polling threads can add rows.
         self.soc_writer = DataWriter(RAW_SOC)
         self.fluid_writer = DataWriter(RAW_FLUID)
+
+        self.node_ips = self._load_nodes()
+        self._discover_and_add_nodes()
+        self._ensure_node_pollers(self.node_ips)
+        self._show_connection_status()
+
+        self.hat = self._init_hat()
+        Thread(target=self._tc_worker, daemon=True).start()
+        Thread(target=self._discovery_worker, daemon=True).start()
 
         if not self.headless:
             self.plot_id = self.after(1000, self._refresh_plot)
@@ -228,25 +257,36 @@ class UnifiedMonitor(ttk.Frame):
         """Add a message to the GUI log and the logger."""
         logging.info(msg)
         self.log.appendleft(f"{datetime.now():%H:%M:%S}  {msg}")
+        if self.headless:
+            return
         for i, lb in enumerate(self.log_labels):
             lb.config(text=self.log[i] if i < len(self.log) else "")
 
     # ───── banner helpers ─────
     def _show_connection_status(self):
+        if self.headless:
+            return
         if hat_list(HatIDs.MCC_134):
             self.hat_banner.configure(text="MCC-134 HAT : OK",background="green",foreground="white")
         else:
             self.hat_banner.configure(text="MCC-134 HAT : NOT FOUND",background="red",foreground="white")
         bad=[]
-        for ip in set(self.node_ips):
+        for ip in sorted(set(self.node_ips)):
+            if ip in self.worker_info and self.worker_info[ip].source == "agent":
+                if self._agent_status(ip, timeout=0.5) is None:
+                    bad.append(ip)
+                continue
             try: subprocess.check_output(f"ssh {SSH_OPTS} pi@{ip} 'echo ok'",shell=True,timeout=4)
             except subprocess.SubprocessError: bad.append(ip)
         if bad:
             self.node_banner.configure(text="Nodes missing: "+", ".join(bad),
                                        background="red",foreground="white")
-        else:
-            self.node_banner.configure(text="All nodes reachable",
+        elif self.node_ips:
+            self.node_banner.configure(text=f"Nodes reachable: {len(set(self.node_ips))}",
                                        background="green",foreground="white")
+        else:
+            self.node_banner.configure(text="No nodes found",
+                                       background="orange",foreground="black")
 
     # ───── helpers ─────
     def _toggle_full(self):
@@ -296,15 +336,24 @@ class UnifiedMonitor(ttk.Frame):
         self.log_msg("Rebooting nodes…")
         workers=[ip for ip in set(self.node_ips) if ip!=self.local_ip]
         for ip in workers:
-            subprocess.Popen(f"ssh {SSH_OPTS} pi@{ip} 'sudo reboot &'",shell=True)
+            if ip in self.worker_info and self.worker_info[ip].source == "agent":
+                self._agent_request(ip, "/reboot", method="POST", timeout=1)
+            else:
+                subprocess.Popen(f"ssh {SSH_OPTS} pi@{ip} 'sudo reboot &'",shell=True)
         time.sleep(5)
         for ip in workers:
             while True:
-                try:
-                    subprocess.check_output(f"ssh {SSH_OPTS} pi@{ip} 'echo ok'",
-                                            shell=True,timeout=5)
-                    break
-                except subprocess.SubprocessError: time.sleep(2)
+                if ip in self.worker_info and self.worker_info[ip].source == "agent":
+                    if self._agent_status(ip, timeout=2) is not None:
+                        break
+                else:
+                    try:
+                        subprocess.check_output(f"ssh {SSH_OPTS} pi@{ip} 'echo ok'",
+                                                shell=True,timeout=5)
+                        break
+                    except subprocess.SubprocessError:
+                        pass
+                time.sleep(2)
         self.log_msg("All nodes back online")
         self._show_connection_status()
         self.reboot_btn.configure(state=tk.NORMAL)
@@ -365,6 +414,15 @@ class UnifiedMonitor(ttk.Frame):
         rem_cmd=("stress-ng --cpu 0 --cpu-load 100 --io 2 --matrix 0 "
                  "--vm 4 --vm-bytes 95% --memcpy 2 "+t_opt).replace('"','\\"')
         for ip in set(self.node_ips):
+            if ip in self.worker_info and self.worker_info[ip].source == "agent":
+                self._agent_request(
+                    ip,
+                    "/stress/start",
+                    method="POST",
+                    payload={"seconds": seconds},
+                    timeout=3,
+                )
+                continue
             subprocess.Popen(f"ssh {SSH_OPTS} pi@{ip} \"{gov}\"",shell=True)
             if ip!=self.local_ip:
                 subprocess.Popen(f"ssh {SSH_OPTS} pi@{ip} "
@@ -373,7 +431,10 @@ class UnifiedMonitor(ttk.Frame):
         tools='pkill -9 -f "stress-ng" ; pkill -9 -f "stress "'
         subprocess.call(tools,shell=True)
         for ip in set(self.node_ips):
-            subprocess.Popen(f"ssh {SSH_OPTS} pi@{ip} \"{tools}\"",shell=True)
+            if ip in self.worker_info and self.worker_info[ip].source == "agent":
+                self._agent_request(ip, "/stress/stop", method="POST", timeout=2)
+            else:
+                subprocess.Popen(f"ssh {SSH_OPTS} pi@{ip} \"{tools}\"",shell=True)
 
     # ───── timer / banner ─────
     def _tick(self):
@@ -409,8 +470,21 @@ class UnifiedMonitor(ttk.Frame):
         self.tick_id=self.after(1000,self._tick)
 
     # ───── node polling + raw CSV ─────
+    def _get_local_ip(self) -> str:
+        """Return the outbound IP address without depending on hostname DNS."""
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+                s.connect(("8.8.8.8", 80))
+                return s.getsockname()[0]
+        except OSError:
+            return "127.0.0.1"
+
     def _load_nodes(self):
+        """Load optional static SSH fallback nodes from NODES_FILE."""
         if not os.path.exists(NODES_FILE):
+            if DISCOVERY_CIDR:
+                logging.info("%s missing; relying on agent discovery", NODES_FILE)
+                return []
             messagebox.showerror("Config",f"{NODES_FILE} missing"); sys.exit(1)
         ips=[]
         with open(NODES_FILE) as f:
@@ -420,7 +494,105 @@ class UnifiedMonitor(ttk.Frame):
                 parts=ln.split(); ip=parts[0]
                 slots=int(parts[1].split("=")[1]) if len(parts)>1 and "=" in parts[1] else 1
                 ips.extend([ip]*slots)
+                self.worker_info.setdefault(
+                    ip,
+                    WorkerInfo(ip=ip, node_id=ip, hostname=ip, source="ssh"),
+                )
         return ips
+
+    def _agent_url(self, ip: str, path: str) -> str:
+        return f"http://{ip}:{AGENT_PORT}{path}"
+
+    def _agent_request(
+        self,
+        ip: str,
+        path: str,
+        method: str = "GET",
+        payload: dict | None = None,
+        timeout: float = 1.0,
+    ) -> dict | None:
+        data = None
+        headers = {}
+        if payload is not None:
+            data = json.dumps(payload).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        req = urllib.request.Request(
+            self._agent_url(ip, path),
+            data=data,
+            headers=headers,
+            method=method,
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                raw = resp.read().decode("utf-8")
+                return json.loads(raw) if raw else {}
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError):
+            return None
+
+    def _agent_status(self, ip: str, timeout: float = 1.0) -> dict | None:
+        return self._agent_request(ip, "/status", timeout=timeout)
+
+    def _discover_agent_nodes(self) -> dict[str, WorkerInfo]:
+        """Scan the configured CIDR and return worker agents that answer."""
+        if not DISCOVERY_CIDR:
+            return {}
+        try:
+            hosts = [str(h) for h in ipaddress.ip_network(DISCOVERY_CIDR, strict=False).hosts()]
+        except ValueError as exc:
+            logging.warning("Invalid discovery CIDR %r: %s", DISCOVERY_CIDR, exc)
+            return {}
+
+        found: dict[str, WorkerInfo] = {}
+        with ThreadPoolExecutor(max_workers=64) as pool:
+            futures = {pool.submit(self._agent_status, ip, 0.35): ip for ip in hosts}
+            for fut in as_completed(futures):
+                ip = futures[fut]
+                try:
+                    status = fut.result()
+                except Exception:  # noqa: broad-except
+                    status = None
+                if not status:
+                    continue
+                node_id = str(status.get("id") or ip)
+                hostname = str(status.get("hostname") or node_id)
+                found[ip] = WorkerInfo(
+                    ip=ip,
+                    node_id=node_id,
+                    hostname=hostname,
+                    source="agent",
+                )
+        return found
+
+    def _discover_and_add_nodes(self) -> None:
+        """Add newly discovered worker agents without disturbing SSH fallback nodes."""
+        discovered = self._discover_agent_nodes()
+        if not discovered:
+            return
+        with self.nodes_lock:
+            changed = False
+            for ip, info in discovered.items():
+                self.worker_info[ip] = info
+                if ip not in self.node_ips:
+                    self.node_ips.append(ip)
+                    changed = True
+            if changed:
+                self.log_msg(f"Discovered {len(discovered)} worker agent(s)")
+
+    def _discovery_worker(self) -> None:
+        """Refresh worker discovery periodically while the dashboard is running."""
+        while not self.stop.is_set():
+            self._discover_and_add_nodes()
+            self._ensure_node_pollers(self.node_ips)
+            self.stop.wait(15)
+
+    def _ensure_node_pollers(self, ips: list[str]) -> None:
+        """Start exactly one polling thread per IP."""
+        with self.nodes_lock:
+            new_ips = [ip for ip in set(ips) if ip not in self.polling_nodes]
+            self.polling_nodes.update(new_ips)
+        for ip in new_ips:
+            Thread(target=self._poll_node, args=(ip,), daemon=True).start()
+
     def _save_raw_soc(self, row: pd.Series) -> None:
         """Queue a SoC temperature row for disk writing."""
         self.soc_writer.write_row(row)
@@ -431,16 +603,34 @@ class UnifiedMonitor(ttk.Frame):
 
     def _poll_node(self,ip):
         while not self.stop.is_set():
-            t,c=self._read_stats(ip); now=datetime.now()
-            if t==0: time.sleep(1); continue     # filter failed SSH reading
-            row=pd.Series({"Time":now,"Node":ip,"Temp":t,"Clock":c})
+            t,c,u=self._read_stats(ip); now=datetime.now()
+            if t==0: time.sleep(1); continue     # filter failed reading
+            info = self.worker_info.get(ip)
+            label = info.label if info else ip
+            row=pd.Series({"Time":now,"Node":label,"Temp":t,"Clock":c,"Usage":u})
             self._save_raw_soc(row)
             with self.cl_lock:
                 self.cl_df=pd.concat([self.cl_df,row.to_frame().T],ignore_index=True)
                 self._trim(self.cl_df)
             time.sleep(1)
-    def _read_stats(self, ip: str) -> tuple[float, int]:
-        """Read temperature and clock from a node via SSH."""
+
+    def _read_stats(self, ip: str) -> tuple[float, float, float | None]:
+        """Read temperature, clock, and optional CPU usage from a node."""
+        status = self._agent_status(ip, timeout=0.8)
+        if status:
+            node_id = str(status.get("id") or ip)
+            hostname = str(status.get("hostname") or node_id)
+            self.worker_info[ip] = WorkerInfo(
+                ip=ip,
+                node_id=node_id,
+                hostname=hostname,
+                source="agent",
+            )
+            return (
+                float(status.get("cpu_temp_c") or 0),
+                float(status.get("cpu_clock_mhz") or 0),
+                status.get("cpu_usage_percent"),
+            )
         try:
             if ip == self.local_ip:
                 t = float(open("/sys/class/thermal/thermal_zone0/temp").read()) / 1000
@@ -449,7 +639,7 @@ class UnifiedMonitor(ttk.Frame):
                         "/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq"
                     ).read()
                 ) / 1000
-                return t, c
+                return t, c, None
             t = float(
                 subprocess.check_output(
                     f"ssh {SSH_OPTS} pi@{ip} cat /sys/class/thermal/thermal_zone0/temp",
@@ -462,13 +652,13 @@ class UnifiedMonitor(ttk.Frame):
                     shell=True,
                 ).strip()
             ) / 1000
-            return t, c
+            return t, c, None
         except subprocess.SubprocessError as exc:
-            logging.warning("SSH read failed for %s: %s", ip, exc)
-            return 0, 0
+            logging.warning("Node read failed for %s: %s", ip, exc)
+            return 0, 0, None
         except Exception as exc:  # noqa: broad-except
             logging.exception("Error reading stats from %s", ip)
-            return 0, 0
+            return 0, 0, None
     @staticmethod
     def _trim(df):
         cutoff=datetime.now()-timedelta(hours=DISPLAY_H)
@@ -520,13 +710,23 @@ class UnifiedMonitor(ttk.Frame):
     def _refresh_plot(self):
         self.ax.cla(); lines=[]; labels=[]
         with self.cl_lock: d=self.cl_df.copy()
-        cmap={ip:self.COLORS[i%len(self.COLORS)] for i,ip in enumerate(sorted(set(self.node_ips)))}
-        for ip,col in cmap.items():
-            s=d[(d.Node==ip)&(d.Temp>0)]
+        with self.nodes_lock:
+            node_labels = sorted(
+                {
+                    (self.worker_info[ip].label if ip in self.worker_info else ip)
+                    for ip in self.node_ips
+                }
+            )
+        cmap={node:self.COLORS[i%len(self.COLORS)] for i,node in enumerate(node_labels)}
+        for node,col in cmap.items():
+            s=d[(d.Node==node)&(d.Temp>0)]
             if not s.empty:
                 l,=self.ax.plot(s.Time,s.Temp,color=col,linewidth=2.2)
                 tb=fr"$\mathbf{{{s.Temp.iloc[-1]:.1f}\,°C}}$"
-                labels.append(f"{ip}  {s.Clock.iloc[-1]/1000:.2f} GHz\n{tb}"); lines.append(l)
+                usage = ""
+                if "Usage" in s and pd.notna(s.Usage.iloc[-1]):
+                    usage = f"  CPU {float(s.Usage.iloc[-1]):.0f}%"
+                labels.append(f"{node}  {s.Clock.iloc[-1]/1000:.2f} GHz{usage}\n{tb}"); lines.append(l)
         with self.tc_lock: f=self.tc_df.copy()
         offset=len(cmap)
         for idx,ch in enumerate(self.FLUID_ORDER):
@@ -607,7 +807,7 @@ class UnifiedMonitor(ttk.Frame):
             self.soc_writer.flush()
             self.fluid_writer.flush()
 
-            soc_cols = ["Time", "Node", "Temp", "Clock"]
+            soc_cols = ["Time", "Node", "Temp", "Clock", "Usage"]
             if RAW_SOC.exists() and RAW_SOC.stat().st_size > 0:
                 try:
                     soc_src = pd.read_csv(RAW_SOC, parse_dates=["Time"])
@@ -633,12 +833,18 @@ class UnifiedMonitor(ttk.Frame):
         # relative-minute column
         cl["Time"] = pd.to_datetime(cl["Time"], errors="coerce")
         fl["Time"] = pd.to_datetime(fl["Time"], errors="coerce")
-        ref=self.stress_start if self.stress_start else cl["Time"].iloc[0]
+        if cl.empty and fl.empty:
+            self.log_msg("No data to export")
+            return
+        if not cl.empty:
+            ref = self.stress_start if self.stress_start else cl["Time"].iloc[0]
+        else:
+            ref = self.stress_start if self.stress_start else fl["Time"].iloc[0]
         cl["rel_min"]=cl["Time"].sub(ref).dt.total_seconds().div(60)
         fl["rel_min"]=fl["Time"].sub(ref).dt.total_seconds().div(60)
 
         # average down to keep file light while retaining node/channel info
-        cl = self._avg_df(cl, ["Temp", "Clock", "rel_min"], ["Node"])
+        cl = self._avg_df(cl, ["Temp", "Clock", "Usage", "rel_min"], ["Node"])
         fl = self._avg_df(fl, ["Temp", "rel_min"], ["Channel"])
 
         # pivot (ensure only numeric columns are aggregated)
@@ -747,10 +953,23 @@ def main():
     parser.add_argument(
         "--headless", action="store_true", help="Run without showing the GUI"
     )
+    parser.add_argument(
+        "--agent-port",
+        type=int,
+        default=DEFAULT_AGENT_PORT,
+        help="HTTP worker-agent port",
+    )
+    parser.add_argument(
+        "--discovery-cidr",
+        default=DEFAULT_DISCOVERY_CIDR,
+        help="CIDR range to scan for worker agents, e.g. 10.50.0.0/24",
+    )
     args = parser.parse_args()
 
-    global NODES_FILE, CSV_DIR, RAW_SOC, RAW_FLUID
+    global NODES_FILE, CSV_DIR, RAW_SOC, RAW_FLUID, AGENT_PORT, DISCOVERY_CIDR
     NODES_FILE = args.nodes_file
+    AGENT_PORT = args.agent_port
+    DISCOVERY_CIDR = args.discovery_cidr
     CSV_DIR = Path(args.csv_dir)
     CSV_DIR.mkdir(parents=True, exist_ok=True)
     RAW_SOC = CSV_DIR / "raw_soc.csv"

--- a/scripts/install_worker.sh
+++ b/scripts/install_worker.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_OWNER="${IMMERSIONMONITOR_REPO_OWNER:-ramorimdias}"
+REPO_NAME="${IMMERSIONMONITOR_REPO_NAME:-immersionmonitor}"
+BRANCH="${IMMERSIONMONITOR_BRANCH:-main}"
+BASE_URL="${IMMERSIONMONITOR_RAW_BASE:-https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/${BRANCH}}"
+INSTALL_DIR="${IMMERSIONMONITOR_INSTALL_DIR:-/opt/immersionmonitor}"
+AGENT_PORT="${BENCH_AGENT_PORT:-8765}"
+SERVICE_NAME="bench-worker-agent.service"
+
+if [[ "${EUID}" -ne 0 ]]; then
+  SUDO="sudo"
+else
+  SUDO=""
+fi
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd curl
+
+echo "Installing bench worker dependencies..."
+${SUDO} apt-get update
+${SUDO} apt-get install -y python3 stress-ng curl ca-certificates
+
+echo "Installing worker agent into ${INSTALL_DIR}..."
+${SUDO} mkdir -p "${INSTALL_DIR}"
+${SUDO} curl -fsSL "${BASE_URL}/worker_agent.py" -o "${INSTALL_DIR}/worker_agent.py"
+${SUDO} chmod 755 "${INSTALL_DIR}/worker_agent.py"
+
+echo "Installing systemd service..."
+TMP_SERVICE="$(mktemp)"
+curl -fsSL "${BASE_URL}/systemd/${SERVICE_NAME}" -o "${TMP_SERVICE}"
+sed -i "s/--port 8765/--port ${AGENT_PORT}/" "${TMP_SERVICE}"
+${SUDO} install -m 0644 "${TMP_SERVICE}" "/etc/systemd/system/${SERVICE_NAME}"
+rm -f "${TMP_SERVICE}"
+
+${SUDO} systemctl daemon-reload
+${SUDO} systemctl enable --now "${SERVICE_NAME}"
+
+echo
+${SUDO} systemctl --no-pager --lines=8 status "${SERVICE_NAME}" || true
+
+echo
+echo "Bench worker agent installed."
+echo "Local check: curl http://127.0.0.1:${AGENT_PORT}/status"
+echo "From head Pi: discover this node on port ${AGENT_PORT}."

--- a/systemd/bench-worker-agent.service
+++ b/systemd/bench-worker-agent.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Bench worker HTTP agent
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 /opt/immersionmonitor/worker_agent.py --host 0.0.0.0 --port 8765
+Restart=always
+RestartSec=3
+User=pi
+WorkingDirectory=/opt/immersionmonitor
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/bench-worker-agent.service
+++ b/systemd/bench-worker-agent.service
@@ -8,7 +8,6 @@ Type=simple
 ExecStart=/usr/bin/python3 /opt/immersionmonitor/worker_agent.py --host 0.0.0.0 --port 8765
 Restart=always
 RestartSec=3
-User=pi
 WorkingDirectory=/opt/immersionmonitor
 
 [Install]

--- a/worker_agent.py
+++ b/worker_agent.py
@@ -40,6 +40,13 @@ stress_proc: subprocess.Popen | None = None
 last_cpu_sample: tuple[float, int, int] | None = None
 
 
+def privileged_cmd(command: list[str]) -> list[str]:
+    """Use sudo only when the agent is not already running as root."""
+    if os.geteuid() == 0:
+        return command
+    return ["sudo", "-n", *command]
+
+
 def read_text(path: str) -> str | None:
     try:
         return Path(path).read_text().strip()
@@ -118,13 +125,23 @@ def stress_running() -> bool:
 
 
 def set_performance_governor() -> None:
-    command = (
-        "for g in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do "
-        "echo performance | sudo -n tee \"$g\" >/dev/null; done; "
-        "[ -e /sys/devices/system/cpu/cpufreq/boost ] && "
-        "echo 1 | sudo -n tee /sys/devices/system/cpu/cpufreq/boost >/dev/null || true"
-    )
-    subprocess.run(command, shell=True, check=False)
+    for path in Path("/sys/devices/system/cpu").glob("cpu*/cpufreq/scaling_governor"):
+        subprocess.run(
+            privileged_cmd(["tee", str(path)]),
+            input=b"performance\n",
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    boost = Path("/sys/devices/system/cpu/cpufreq/boost")
+    if boost.exists():
+        subprocess.run(
+            privileged_cmd(["tee", str(boost)]),
+            input=b"1\n",
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
 
 
 def start_stress(seconds: int | None = None) -> None:
@@ -196,7 +213,7 @@ class Handler(BaseHTTPRequestHandler):
             self._send_json({"ok": True, "stress_running": False})
         elif self.path == "/reboot":
             self._send_json({"ok": True, "rebooting": True})
-            subprocess.Popen(["sudo", "reboot"])
+            subprocess.Popen(privileged_cmd(["reboot"]))
         else:
             self._send_json({"error": "not found"}, 404)
 

--- a/worker_agent.py
+++ b/worker_agent.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""HTTP worker agent for Raspberry Pi bench nodes.
+
+Run this on each worker Pi. The head Pi discovers it over the bench network,
+reads metrics from /status, and controls stress-ng through /stress/start and
+/stress/stop.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import subprocess
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+STRESS_ARGS = [
+    "stress-ng",
+    "--cpu",
+    "0",
+    "--cpu-load",
+    "100",
+    "--io",
+    "2",
+    "--matrix",
+    "0",
+    "--vm",
+    "4",
+    "--vm-bytes",
+    "95%",
+    "--memcpy",
+    "2",
+]
+
+stress_proc: subprocess.Popen | None = None
+last_cpu_sample: tuple[float, int, int] | None = None
+
+
+def read_text(path: str) -> str | None:
+    try:
+        return Path(path).read_text().strip()
+    except OSError:
+        return None
+
+
+def read_serial() -> str:
+    cpuinfo = read_text("/proc/cpuinfo") or ""
+    for line in cpuinfo.splitlines():
+        if line.startswith("Serial"):
+            return line.split(":", 1)[1].strip()
+    machine_id = read_text("/etc/machine-id")
+    return machine_id or socket.gethostname()
+
+
+def read_temp_c() -> float | None:
+    raw = read_text("/sys/class/thermal/thermal_zone0/temp")
+    if raw is None:
+        return None
+    try:
+        return round(float(raw) / 1000.0, 2)
+    except ValueError:
+        return None
+
+
+def read_clock_mhz() -> float | None:
+    raw = read_text("/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq")
+    if raw is None:
+        return None
+    try:
+        return round(float(raw) / 1000.0, 1)
+    except ValueError:
+        return None
+
+
+def _read_proc_stat() -> tuple[int, int] | None:
+    stat = read_text("/proc/stat")
+    if not stat:
+        return None
+    first = stat.splitlines()[0].split()[1:]
+    try:
+        values = [int(v) for v in first]
+    except ValueError:
+        return None
+    idle = values[3] + (values[4] if len(values) > 4 else 0)
+    total = sum(values)
+    return total, idle
+
+
+def cpu_usage_percent() -> float | None:
+    global last_cpu_sample
+    current = _read_proc_stat()
+    if current is None:
+        return None
+    now = time.monotonic()
+    if last_cpu_sample is None:
+        last_cpu_sample = (now, current[0], current[1])
+        return None
+    _, prev_total, prev_idle = last_cpu_sample
+    last_cpu_sample = (now, current[0], current[1])
+    total_delta = current[0] - prev_total
+    idle_delta = current[1] - prev_idle
+    if total_delta <= 0:
+        return None
+    return round(100.0 * (1.0 - idle_delta / total_delta), 1)
+
+
+def stress_running() -> bool:
+    global stress_proc
+    if stress_proc is not None and stress_proc.poll() is None:
+        return True
+    stress_proc = None
+    result = subprocess.run(["pgrep", "-f", "stress-ng"], capture_output=True)
+    return result.returncode == 0
+
+
+def set_performance_governor() -> None:
+    command = (
+        "for g in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do "
+        "echo performance | sudo -n tee \"$g\" >/dev/null; done; "
+        "[ -e /sys/devices/system/cpu/cpufreq/boost ] && "
+        "echo 1 | sudo -n tee /sys/devices/system/cpu/cpufreq/boost >/dev/null || true"
+    )
+    subprocess.run(command, shell=True, check=False)
+
+
+def start_stress(seconds: int | None = None) -> None:
+    global stress_proc
+    if stress_running():
+        return
+    set_performance_governor()
+    cmd = STRESS_ARGS.copy()
+    if seconds and seconds > 0:
+        cmd += ["--timeout", f"{int(seconds)}s"]
+    stress_proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def stop_stress() -> None:
+    global stress_proc
+    subprocess.run(["pkill", "-9", "-f", "stress-ng"], check=False)
+    stress_proc = None
+
+
+def status_payload() -> dict[str, Any]:
+    return {
+        "id": read_serial(),
+        "hostname": socket.gethostname(),
+        "cpu_temp_c": read_temp_c(),
+        "cpu_clock_mhz": read_clock_mhz(),
+        "cpu_usage_percent": cpu_usage_percent(),
+        "stress_running": stress_running(),
+        "uptime_s": round(time.monotonic()),
+    }
+
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "BenchWorkerAgent/1.0"
+
+    def _read_json(self) -> dict[str, Any]:
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        if length <= 0:
+            return {}
+        try:
+            return json.loads(self.rfile.read(length).decode("utf-8"))
+        except json.JSONDecodeError:
+            return {}
+
+    def _send_json(self, payload: dict[str, Any], status: int = 200) -> None:
+        data = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        return
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path == "/status":
+            self._send_json(status_payload())
+        else:
+            self._send_json({"error": "not found"}, 404)
+
+    def do_POST(self) -> None:  # noqa: N802
+        payload = self._read_json()
+        if self.path == "/stress/start":
+            seconds = payload.get("seconds")
+            start_stress(int(seconds) if seconds is not None else None)
+            self._send_json({"ok": True, "stress_running": stress_running()})
+        elif self.path == "/stress/stop":
+            stop_stress()
+            self._send_json({"ok": True, "stress_running": False})
+        elif self.path == "/reboot":
+            self._send_json({"ok": True, "rebooting": True})
+            subprocess.Popen(["sudo", "reboot"])
+        else:
+            self._send_json({"error": "not found"}, 404)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Bench worker HTTP agent")
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=int(os.environ.get("BENCH_AGENT_PORT", "8765")))
+    args = parser.parse_args()
+
+    server = ThreadingHTTPServer((args.host, args.port), Handler)
+    print(f"worker agent listening on {args.host}:{args.port}", flush=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        stop_stress()
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `worker_agent.py`, a lightweight HTTP agent for worker Raspberry Pis.
- Updates `dual_monitor.py` to discover worker agents over a configurable CIDR while preserving the existing `/home/motul/nodes_ips` SSH fallback.
- Adds worker start/stop/reboot control through HTTP endpoints when a node is running the agent.
- Adds CPU usage reporting from worker agents and keeps CPU temperature/clock plotting.
- Fixes initialization order so CSV writers exist before polling threads start.
- Makes headless mode safer by not touching GUI banners/log labels when hidden.
- Adds a systemd service and setup instructions for building a flashable worker image.

## Usage

Worker Pis run:

```bash
python3 worker_agent.py --host 0.0.0.0 --port 8765
```

Head Pi runs discovery with:

```bash
python3 dual_monitor.py --discovery-cidr 10.50.0.0/24 --agent-port 8765
```

Existing SSH mode still works if `/home/motul/nodes_ips` is present.

## Validation

- `python -m py_compile dual_monitor.py`
- `python -m py_compile worker_agent.py`

I did syntax validation locally against the modified files. Hardware-level validation on the Pi bench is still needed, especially MCC-134 access, stress-ng sudo permissions, and network discovery timing.