### PR TITLE
Add head Pi auto-update system

### DIFF
--- a/HEAD_AUTO_UPDATE.md
+++ b/HEAD_AUTO_UPDATE.md
@@ -1,0 +1,92 @@
+# Head Pi auto-update
+
+The head Pi can automatically fetch the latest repository version with a systemd timer.
+
+## Recommended behavior
+
+The updater:
+
+```text
+runs 2 minutes after boot
+runs every day around 06:00
+uses a lock so two updates cannot run at the same time
+fetches the selected GitHub branch
+resets /opt/immersionmonitor to origin/<branch>
+validates Python syntax with py_compile
+optionally restarts a configured systemd service
+```
+
+By default, it does **not** restart the dashboard because this repository does not yet define a head dashboard service. New code is used the next time you start the app.
+
+## Install on a fresh head Pi
+
+After installing Raspberry Pi OS and giving the head Pi internet access, run:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ramorimdias/immersionmonitor/main/scripts/install_head_autoupdate.sh | bash
+```
+
+Until this PR is merged, test from this branch with:
+
+```bash
+IMMERSIONMONITOR_BRANCH=head-auto-update \
+  bash -c "$(curl -fsSL https://raw.githubusercontent.com/ramorimdias/immersionmonitor/head-auto-update/scripts/install_head_autoupdate.sh)"
+```
+
+## Configuration
+
+The installer writes:
+
+```text
+/etc/default/immersionmonitor-update
+```
+
+Default values:
+
+```text
+IMMERSIONMONITOR_REPO_DIR=/opt/immersionmonitor
+IMMERSIONMONITOR_REMOTE=origin
+IMMERSIONMONITOR_BRANCH=main
+IMMERSIONMONITOR_RESTART_SERVICE=
+```
+
+If you later create a systemd service for the head dashboard, set:
+
+```text
+IMMERSIONMONITOR_RESTART_SERVICE=bench-head.service
+```
+
+Then reload systemd:
+
+```bash
+sudo systemctl daemon-reload
+```
+
+## Manual update check
+
+```bash
+sudo systemctl start bench-head-update.service
+```
+
+## Timer status
+
+```bash
+systemctl status bench-head-update.timer
+systemctl list-timers bench-head-update.timer
+```
+
+## Logs
+
+```bash
+journalctl -u bench-head-update.service -n 100 --no-pager
+```
+
+## Disable auto-update
+
+```bash
+sudo systemctl disable --now bench-head-update.timer
+```
+
+## Safety note
+
+Automatic updates are convenient, but avoid restarting the dashboard during an active test. Keep `IMMERSIONMONITOR_RESTART_SERVICE` empty unless the head dashboard service is designed to restart safely.

--- a/scripts/install_head_autoupdate.sh
+++ b/scripts/install_head_autoupdate.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_OWNER="${IMMERSIONMONITOR_REPO_OWNER:-ramorimdias}"
+REPO_NAME="${IMMERSIONMONITOR_REPO_NAME:-immersionmonitor}"
+BRANCH="${IMMERSIONMONITOR_BRANCH:-main}"
+REPO_URL="${IMMERSIONMONITOR_REPO_URL:-https://github.com/${REPO_OWNER}/${REPO_NAME}.git}"
+RAW_BASE="${IMMERSIONMONITOR_RAW_BASE:-https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/${BRANCH}}"
+INSTALL_DIR="${IMMERSIONMONITOR_REPO_DIR:-/opt/immersionmonitor}"
+UPDATE_SERVICE="bench-head-update.service"
+UPDATE_TIMER="bench-head-update.timer"
+RESTART_SERVICE="${IMMERSIONMONITOR_RESTART_SERVICE:-}"
+
+if [[ "${EUID}" -ne 0 ]]; then
+  SUDO="sudo"
+else
+  SUDO=""
+fi
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd curl
+
+echo "Installing update dependencies..."
+${SUDO} apt-get update
+${SUDO} apt-get install -y git curl ca-certificates python3 util-linux
+
+if [[ ! -d "${INSTALL_DIR}/.git" ]]; then
+  if [[ -e "${INSTALL_DIR}" ]]; then
+    echo "ERROR: ${INSTALL_DIR} exists but is not a git repository." >&2
+    exit 1
+  fi
+  echo "Cloning ${REPO_URL} into ${INSTALL_DIR}..."
+  ${SUDO} git clone --branch "${BRANCH}" "${REPO_URL}" "${INSTALL_DIR}"
+else
+  echo "Repository already present at ${INSTALL_DIR}."
+fi
+
+echo "Installing updater script..."
+TMP_UPDATE="$(mktemp)"
+curl -fsSL "${RAW_BASE}/scripts/update_head.sh" -o "${TMP_UPDATE}"
+${SUDO} install -m 0755 "${TMP_UPDATE}" /usr/local/sbin/immersionmonitor-update-head.sh
+rm -f "${TMP_UPDATE}"
+
+echo "Writing updater configuration..."
+TMP_ENV="$(mktemp)"
+cat > "${TMP_ENV}" <<EOF
+IMMERSIONMONITOR_REPO_DIR=${INSTALL_DIR}
+IMMERSIONMONITOR_REMOTE=origin
+IMMERSIONMONITOR_BRANCH=${BRANCH}
+IMMERSIONMONITOR_RESTART_SERVICE=${RESTART_SERVICE}
+EOF
+${SUDO} install -m 0644 "${TMP_ENV}" /etc/default/immersionmonitor-update
+rm -f "${TMP_ENV}"
+
+echo "Installing systemd update service and timer..."
+TMP_SERVICE="$(mktemp)"
+TMP_TIMER="$(mktemp)"
+curl -fsSL "${RAW_BASE}/systemd/${UPDATE_SERVICE}" -o "${TMP_SERVICE}"
+curl -fsSL "${RAW_BASE}/systemd/${UPDATE_TIMER}" -o "${TMP_TIMER}"
+${SUDO} install -m 0644 "${TMP_SERVICE}" "/etc/systemd/system/${UPDATE_SERVICE}"
+${SUDO} install -m 0644 "${TMP_TIMER}" "/etc/systemd/system/${UPDATE_TIMER}"
+rm -f "${TMP_SERVICE}" "${TMP_TIMER}"
+
+${SUDO} systemctl daemon-reload
+${SUDO} systemctl enable --now "${UPDATE_TIMER}"
+
+echo
+echo "Running one immediate update check..."
+${SUDO} systemctl start "${UPDATE_SERVICE}"
+
+echo
+echo "Head Pi auto-update installed."
+echo "Timer status: systemctl status ${UPDATE_TIMER}"
+echo "Update logs: journalctl -u ${UPDATE_SERVICE} -n 50 --no-pager"

--- a/scripts/update_head.sh
+++ b/scripts/update_head.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="${IMMERSIONMONITOR_REPO_DIR:-/opt/immersionmonitor}"
+REMOTE="${IMMERSIONMONITOR_REMOTE:-origin}"
+BRANCH="${IMMERSIONMONITOR_BRANCH:-main}"
+RESTART_SERVICE="${IMMERSIONMONITOR_RESTART_SERVICE:-}"
+LOCK_FILE="${IMMERSIONMONITOR_LOCK_FILE:-/var/lock/immersionmonitor-update.lock}"
+
+if [[ "${EUID}" -ne 0 ]]; then
+  SUDO="sudo"
+else
+  SUDO=""
+fi
+
+log() {
+  echo "[$(date --iso-8601=seconds)] $*"
+}
+
+mkdir -p "$(dirname "${LOCK_FILE}")"
+exec 9>"${LOCK_FILE}"
+if ! flock -n 9; then
+  log "Another update is already running. Exiting."
+  exit 0
+fi
+
+if [[ ! -d "${REPO_DIR}/.git" ]]; then
+  log "ERROR: ${REPO_DIR} is not a git repository."
+  exit 1
+fi
+
+cd "${REPO_DIR}"
+
+current_sha="$(git rev-parse HEAD)"
+log "Current revision: ${current_sha}"
+log "Fetching ${REMOTE}/${BRANCH}..."
+git fetch --prune "${REMOTE}" "${BRANCH}"
+new_sha="$(git rev-parse "${REMOTE}/${BRANCH}")"
+
+if [[ "${current_sha}" == "${new_sha}" ]]; then
+  log "Already up to date."
+  exit 0
+fi
+
+log "Updating to ${new_sha}..."
+git reset --hard "${REMOTE}/${BRANCH}"
+
+if [[ -f dual_monitor.py ]]; then
+  python3 -m py_compile dual_monitor.py
+fi
+if [[ -f worker_agent.py ]]; then
+  python3 -m py_compile worker_agent.py
+fi
+
+log "Update installed successfully."
+
+if [[ -n "${RESTART_SERVICE}" ]]; then
+  if systemctl list-unit-files "${RESTART_SERVICE}" >/dev/null 2>&1; then
+    log "Restarting ${RESTART_SERVICE}..."
+    ${SUDO} systemctl restart "${RESTART_SERVICE}"
+  else
+    log "Restart service ${RESTART_SERVICE} not found. Skipping restart."
+  fi
+else
+  log "No restart service configured. New code will be used next time the app starts."
+fi

--- a/systemd/bench-head-update.service
+++ b/systemd/bench-head-update.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Update immersionmonitor head Pi from GitHub
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=-/etc/default/immersionmonitor-update
+ExecStart=/usr/local/sbin/immersionmonitor-update-head.sh

--- a/systemd/bench-head-update.timer
+++ b/systemd/bench-head-update.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run immersionmonitor head Pi update on boot and daily
+
+[Timer]
+OnBootSec=2min
+OnCalendar=*-*-* 06:00:00
+Persistent=true
+RandomizedDelaySec=5min
+Unit=bench-head-update.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

Adds a systemd-based auto-update mechanism for the head Raspberry Pi.

New files:

- `scripts/update_head.sh`
- `scripts/install_head_autoupdate.sh`
- `systemd/bench-head-update.service`
- `systemd/bench-head-update.timer`
- `HEAD_AUTO_UPDATE.md`

## Behavior

- Installs/clones the repo to `/opt/immersionmonitor`.
- Runs an update check 2 minutes after boot.
- Runs daily around 06:00 with a small randomized delay.
- Fetches the configured branch from GitHub.
- Hard-resets the local checkout to `origin/<branch>`.
- Runs `python3 -m py_compile` on `dual_monitor.py` and `worker_agent.py` when present.
- Uses a lock file so two update jobs cannot run simultaneously.
- Does not restart the dashboard by default, to avoid interrupting active tests.

## Install after merge

```bash
curl -fsSL https://raw.githubusercontent.com/ramorimdias/immersionmonitor/main/scripts/install_head_autoupdate.sh | bash
```

## Test before merge

```bash
IMMERSIONMONITOR_BRANCH=head-auto-update \
  bash -c "$(curl -fsSL https://raw.githubusercontent.com/ramorimdias/immersionmonitor/head-auto-update/scripts/install_head_autoupdate.sh)"
```

## Notes

The head Pi needs internet access when the timer runs. If the head Pi is only connected to the isolated bench switch, the update check will fail until internet is restored.