### PR TITLE
Add no-screen worker first-boot provisioning

### DIFF
--- a/DASHBOARD_READABILITY.md
+++ b/DASHBOARD_READABILITY.md
@@ -30,7 +30,24 @@ Worker table shows state, hostname, IP, source, temperature, clock, CPU, and las
 Operator help text explains what to check when workers are missing
 ```
 
-## Run it
+## Recommended run command
+
+Use the auto launcher so the head Pi scans the correct subnet whether it is on `192.168.50.x` or `10.50.0.x`:
+
+```bash
+cd /opt/immersionmonitor
+bash scripts/run_readable_monitor_auto.sh
+```
+
+The auto launcher selects:
+
+```text
+Head IP 192.168.50.x  -> scans 192.168.50.0/24
+Head IP 10.50.0.x     -> scans 10.50.0.0/24
+Other private IP      -> scans that /24 subnet
+```
+
+## Manual run commands
 
 Default discovery-only mode:
 
@@ -48,7 +65,15 @@ This scans the default bench subnet:
 Use another subnet if needed:
 
 ```bash
-python3 readable_monitor.py --discovery-cidr 10.50.1.0/24 --agent-port 8765
+python3 readable_monitor.py --discovery-cidr 192.168.50.0/24 --agent-port 8765
+python3 readable_monitor.py --discovery-cidr 10.50.0.0/24 --agent-port 8765
+```
+
+You can also force the auto launcher:
+
+```bash
+DISCOVERY_CIDR=192.168.50.0/24 bash scripts/run_readable_monitor_auto.sh
+DISCOVERY_CIDR=10.50.0.0/24 bash scripts/run_readable_monitor_auto.sh
 ```
 
 The old dashboard still works and keeps its previous behavior:
@@ -87,8 +112,10 @@ curl http://127.0.0.1:8765/status
 hostname -I
 ```
 
-Useful head Pi command:
+Useful head Pi commands:
 
 ```bash
+bash scripts/run_readable_monitor_auto.sh
+python3 readable_monitor.py --discovery-cidr 192.168.50.0/24 --agent-port 8765
 python3 readable_monitor.py --discovery-cidr 10.50.0.0/24 --agent-port 8765
 ```

--- a/WORKER_FIRSTBOOT.md
+++ b/WORKER_FIRSTBOOT.md
@@ -1,0 +1,99 @@
+# Worker first-boot provisioning
+
+This is the no-screen, no-keyboard worker setup path.
+
+Goal:
+
+```text
+Flash Raspberry Pi OS Lite
+Prepare the SD card boot partition once
+Insert SD card into worker Pi
+Connect Ethernet and power
+Worker installs itself on first boot
+Move worker to the bench switch
+Head Pi discovers it automatically
+```
+
+## Requirements
+
+During first boot, the worker must have:
+
+```text
+Ethernet connection
+Internet access
+DHCP
+```
+
+Internet is needed only for first installation because the worker downloads packages and the latest repository files. After installation, the worker can run on the isolated bench network.
+
+## Prepare the SD card from Linux
+
+1. Flash **Raspberry Pi OS Lite 64-bit** with Raspberry Pi Imager.
+2. Remove and reinsert the SD card so the `bootfs` partition is mounted.
+3. Run:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ramorimdias/immersionmonitor/main/scripts/prepare_worker_bootfs.sh -o /tmp/prepare_worker_bootfs.sh
+bash /tmp/prepare_worker_bootfs.sh /media/$USER/bootfs
+```
+
+If your mount path is different, replace `/media/$USER/bootfs` with the mounted boot partition path.
+
+## Test before this PR is merged
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ramorimdias/immersionmonitor/worker-firstboot-provisioning/scripts/prepare_worker_bootfs.sh -o /tmp/prepare_worker_bootfs.sh
+IMMERSIONMONITOR_BRANCH=worker-firstboot-provisioning bash /tmp/prepare_worker_bootfs.sh /media/$USER/bootfs
+```
+
+## What the preparation script does
+
+```text
+Copies worker_firstboot.sh to the FAT boot partition
+Adds a systemd.run first-boot hook to cmdline.txt
+Enables SSH by creating the bootfs ssh marker file
+```
+
+## What happens on first boot
+
+The worker Pi:
+
+```text
+waits for network
+runs apt update
+installs python3, stress-ng, curl, ca-certificates
+copies worker_agent.py to /opt/immersionmonitor
+installs bench-worker-agent.service
+removes the first-boot hook from cmdline.txt
+reboots
+starts the worker agent automatically after reboot
+```
+
+Log file on the SD boot partition:
+
+```text
+/boot/firmware/immersionmonitor-firstboot.log
+```
+
+If provisioning fails, the first-boot hook is left in place so the worker retries on the next boot.
+
+## After installation
+
+Move the worker Pi to the bench switch.
+
+On the head Pi, run:
+
+```bash
+cd /opt/immersionmonitor
+python3 readable_monitor.py
+```
+
+The readable dashboard scans the default bench subnet:
+
+```text
+10.50.0.0/24
+```
+
+## Important limitation
+
+This is not a fully offline image. It is a first-boot installer. For a fully offline worker SD card, build a custom Raspberry Pi OS image with all packages and files already embedded.

--- a/WORKER_FIRSTBOOT.md
+++ b/WORKER_FIRSTBOOT.md
@@ -26,6 +26,75 @@ DHCP
 
 Internet is needed only for first installation because the worker downloads packages and the latest repository files. After installation, the worker can run on the isolated bench network.
 
+## Important Raspberry Pi Imager settings
+
+When flashing the SD card, open Raspberry Pi Imager advanced settings and set at least:
+
+```text
+Hostname: bench-worker
+Username and password: set them explicitly
+SSH: enabled
+Wi-Fi: optional, Ethernet is preferred
+```
+
+Modern Raspberry Pi OS images do not have the old default `pi` user unless you configure a user. Set the user in Raspberry Pi Imager even if you do not plan to use keyboard/screen.
+
+## What goes on the SD card
+
+After flashing, Windows shows only the small FAT boot partition. It usually appears as a drive such as:
+
+```text
+D:\
+E:\
+F:\
+```
+
+This is the partition that contains files like:
+
+```text
+cmdline.txt
+config.txt
+kernel8.img
+```
+
+That partition is the place where the preparation script writes:
+
+```text
+worker_firstboot.sh      at the root of the boot partition
+ssh                      empty marker file at the root of the boot partition
+cmdline.txt              modified by adding a first-boot systemd.run hook
+```
+
+Example if Windows mounts the SD card as `E:`:
+
+```text
+E:\worker_firstboot.sh
+E:\ssh
+E:\cmdline.txt   modified, not replaced
+```
+
+Do not put these files inside a folder. They must be at the root of the visible Raspberry Pi boot drive.
+
+## Prepare the SD card from Windows
+
+1. Flash **Raspberry Pi OS Lite 64-bit** with Raspberry Pi Imager.
+2. Eject and reinsert the SD card if Windows does not show the boot drive.
+3. Open PowerShell.
+4. Replace `E:` below with the SD card boot drive letter visible in File Explorer.
+5. Run:
+
+```powershell
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/ramorimdias/immersionmonitor/main/scripts/prepare_worker_bootfs.ps1" -OutFile "$env:TEMP\prepare_worker_bootfs.ps1"
+powershell -ExecutionPolicy Bypass -File "$env:TEMP\prepare_worker_bootfs.ps1" -BootDrive E:
+```
+
+## Test from Windows before this PR is merged
+
+```powershell
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/ramorimdias/immersionmonitor/worker-firstboot-provisioning/scripts/prepare_worker_bootfs.ps1" -OutFile "$env:TEMP\prepare_worker_bootfs.ps1"
+powershell -ExecutionPolicy Bypass -File "$env:TEMP\prepare_worker_bootfs.ps1" -BootDrive E: -Branch worker-firstboot-provisioning
+```
+
 ## Prepare the SD card from Linux
 
 1. Flash **Raspberry Pi OS Lite 64-bit** with Raspberry Pi Imager.
@@ -39,7 +108,7 @@ bash /tmp/prepare_worker_bootfs.sh /media/$USER/bootfs
 
 If your mount path is different, replace `/media/$USER/bootfs` with the mounted boot partition path.
 
-## Test before this PR is merged
+## Test from Linux before this PR is merged
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/ramorimdias/immersionmonitor/worker-firstboot-provisioning/scripts/prepare_worker_bootfs.sh -o /tmp/prepare_worker_bootfs.sh

--- a/WORKER_FIRSTBOOT.md
+++ b/WORKER_FIRSTBOOT.md
@@ -67,13 +67,13 @@ immersionmonitor-wifi.env       optional Wi-Fi config at the root of the boot pa
 cmdline.txt                     modified by adding a first-boot systemd.run hook
 ```
 
-Example if Windows mounts the SD card as `E:`:
+Example if Windows mounts the SD card as `D:`:
 
 ```text
-E:\worker_firstboot.sh
-E:\ssh
-E:\immersionmonitor-wifi.env
-E:\cmdline.txt   modified, not replaced
+D:\worker_firstboot.sh
+D:\ssh
+D:\immersionmonitor-wifi.env
+D:\cmdline.txt   modified, not replaced
 ```
 
 Do not put these files inside a folder. They must be at the root of the visible Raspberry Pi boot drive.
@@ -83,19 +83,19 @@ Do not put these files inside a folder. They must be at the root of the visible 
 1. Flash **Raspberry Pi OS Lite 64-bit** with Raspberry Pi Imager.
 2. Eject and reinsert the SD card if Windows does not show the boot drive.
 3. Open PowerShell.
-4. Replace `E:` below with the SD card boot drive letter visible in File Explorer.
+4. Replace `D:` below if the SD card uses another boot drive letter.
 5. Run:
 
 ```powershell
 Invoke-WebRequest -Uri "https://raw.githubusercontent.com/ramorimdias/immersionmonitor/main/scripts/prepare_worker_bootfs.ps1" -OutFile "$env:TEMP\prepare_worker_bootfs.ps1"
-powershell -ExecutionPolicy Bypass -File "$env:TEMP\prepare_worker_bootfs.ps1" -BootDrive E: -WifiSsid "Motul-Guest" -WifiPassword "Welcome-2-Motul!" -WifiCountry FR
+powershell -ExecutionPolicy Bypass -File "$env:TEMP\prepare_worker_bootfs.ps1" -BootDrive D: -WifiSsid "Motul-Guest" -WifiPassword "Welcome-2-Motul!" -WifiCountry FR
 ```
 
 ## Test from Windows before this PR is merged
 
 ```powershell
 Invoke-WebRequest -Uri "https://raw.githubusercontent.com/ramorimdias/immersionmonitor/worker-firstboot-provisioning/scripts/prepare_worker_bootfs.ps1" -OutFile "$env:TEMP\prepare_worker_bootfs.ps1"
-powershell -ExecutionPolicy Bypass -File "$env:TEMP\prepare_worker_bootfs.ps1" -BootDrive E: -Branch worker-firstboot-provisioning -WifiSsid "Motul-Guest" -WifiPassword "Welcome-2-Motul!" -WifiCountry FR
+powershell -ExecutionPolicy Bypass -File "$env:TEMP\prepare_worker_bootfs.ps1" -BootDrive D: -Branch worker-firstboot-provisioning -WifiSsid "Motul-Guest" -WifiPassword "Welcome-2-Motul!" -WifiCountry FR
 ```
 
 ## Prepare the SD card from Windows without Wi-Fi
@@ -104,7 +104,7 @@ Use this only if the worker first boot will use Ethernet with internet access:
 
 ```powershell
 Invoke-WebRequest -Uri "https://raw.githubusercontent.com/ramorimdias/immersionmonitor/main/scripts/prepare_worker_bootfs.ps1" -OutFile "$env:TEMP\prepare_worker_bootfs.ps1"
-powershell -ExecutionPolicy Bypass -File "$env:TEMP\prepare_worker_bootfs.ps1" -BootDrive E:
+powershell -ExecutionPolicy Bypass -File "$env:TEMP\prepare_worker_bootfs.ps1" -BootDrive D:
 ```
 
 ## Prepare the SD card from Linux
@@ -168,17 +168,26 @@ If provisioning fails, the second-stage provisioning service is left enabled so 
 
 Move the worker Pi to the bench switch.
 
-On the head Pi, run:
+On the head Pi, run the auto launcher:
 
 ```bash
 cd /opt/immersionmonitor
-python3 readable_monitor.py
+bash scripts/run_readable_monitor_auto.sh
 ```
 
-The readable dashboard scans the default bench subnet:
+The auto launcher selects the discovery subnet from the head Pi IP:
 
 ```text
-10.50.0.0/24
+Head IP 192.168.50.x  -> scans 192.168.50.0/24
+Head IP 10.50.0.x     -> scans 10.50.0.0/24
+Other private IP      -> scans that /24 subnet
+```
+
+You can still override it manually:
+
+```bash
+DISCOVERY_CIDR=192.168.50.0/24 bash scripts/run_readable_monitor_auto.sh
+DISCOVERY_CIDR=10.50.0.0/24 bash scripts/run_readable_monitor_auto.sh
 ```
 
 ## Important limitation

--- a/WORKER_FIRSTBOOT.md
+++ b/WORKER_FIRSTBOOT.md
@@ -8,7 +8,7 @@ Goal:
 Flash Raspberry Pi OS Lite
 Prepare the SD card boot partition once
 Insert SD card into worker Pi
-Connect Ethernet and power
+Connect Ethernet or Wi-Fi
 Worker installs itself on first boot
 Move worker to the bench switch
 Head Pi discovers it automatically
@@ -16,12 +16,13 @@ Head Pi discovers it automatically
 
 ## Requirements
 
-During first boot, the worker must have:
+During first installation, the worker must have:
 
 ```text
-Ethernet connection
 Internet access
 DHCP
+DNS
+Access to raw.githubusercontent.com and apt repositories
 ```
 
 Internet is needed only for first installation because the worker downloads packages and the latest repository files. After installation, the worker can run on the isolated bench network.
@@ -34,7 +35,7 @@ When flashing the SD card, open Raspberry Pi Imager advanced settings and set at
 Hostname: bench-worker
 Username and password: set them explicitly
 SSH: enabled
-Wi-Fi: optional, Ethernet is preferred
+Wi-Fi: optional here, because this repo also provides a bootfs Wi-Fi setup path
 ```
 
 Modern Raspberry Pi OS images do not have the old default `pi` user unless you configure a user. Set the user in Raspberry Pi Imager even if you do not plan to use keyboard/screen.
@@ -60,9 +61,10 @@ kernel8.img
 That partition is the place where the preparation script writes:
 
 ```text
-worker_firstboot.sh      at the root of the boot partition
-ssh                      empty marker file at the root of the boot partition
-cmdline.txt              modified by adding a first-boot systemd.run hook
+worker_firstboot.sh             at the root of the boot partition
+ssh                             empty marker file at the root of the boot partition
+immersionmonitor-wifi.env       optional Wi-Fi config at the root of the boot partition
+cmdline.txt                     modified by adding a first-boot systemd.run hook
 ```
 
 Example if Windows mounts the SD card as `E:`:
@@ -70,12 +72,13 @@ Example if Windows mounts the SD card as `E:`:
 ```text
 E:\worker_firstboot.sh
 E:\ssh
+E:\immersionmonitor-wifi.env
 E:\cmdline.txt   modified, not replaced
 ```
 
 Do not put these files inside a folder. They must be at the root of the visible Raspberry Pi boot drive.
 
-## Prepare the SD card from Windows
+## Prepare the SD card from Windows with Wi-Fi
 
 1. Flash **Raspberry Pi OS Lite 64-bit** with Raspberry Pi Imager.
 2. Eject and reinsert the SD card if Windows does not show the boot drive.
@@ -85,14 +88,23 @@ Do not put these files inside a folder. They must be at the root of the visible 
 
 ```powershell
 Invoke-WebRequest -Uri "https://raw.githubusercontent.com/ramorimdias/immersionmonitor/main/scripts/prepare_worker_bootfs.ps1" -OutFile "$env:TEMP\prepare_worker_bootfs.ps1"
-powershell -ExecutionPolicy Bypass -File "$env:TEMP\prepare_worker_bootfs.ps1" -BootDrive E:
+powershell -ExecutionPolicy Bypass -File "$env:TEMP\prepare_worker_bootfs.ps1" -BootDrive E: -WifiSsid "Motul-Guest" -WifiPassword "Welcome-2-Motul!" -WifiCountry FR
 ```
 
 ## Test from Windows before this PR is merged
 
 ```powershell
 Invoke-WebRequest -Uri "https://raw.githubusercontent.com/ramorimdias/immersionmonitor/worker-firstboot-provisioning/scripts/prepare_worker_bootfs.ps1" -OutFile "$env:TEMP\prepare_worker_bootfs.ps1"
-powershell -ExecutionPolicy Bypass -File "$env:TEMP\prepare_worker_bootfs.ps1" -BootDrive E: -Branch worker-firstboot-provisioning
+powershell -ExecutionPolicy Bypass -File "$env:TEMP\prepare_worker_bootfs.ps1" -BootDrive E: -Branch worker-firstboot-provisioning -WifiSsid "Motul-Guest" -WifiPassword "Welcome-2-Motul!" -WifiCountry FR
+```
+
+## Prepare the SD card from Windows without Wi-Fi
+
+Use this only if the worker first boot will use Ethernet with internet access:
+
+```powershell
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/ramorimdias/immersionmonitor/main/scripts/prepare_worker_bootfs.ps1" -OutFile "$env:TEMP\prepare_worker_bootfs.ps1"
+powershell -ExecutionPolicy Bypass -File "$env:TEMP\prepare_worker_bootfs.ps1" -BootDrive E:
 ```
 
 ## Prepare the SD card from Linux
@@ -119,6 +131,7 @@ IMMERSIONMONITOR_BRANCH=worker-firstboot-provisioning bash /tmp/prepare_worker_b
 
 ```text
 Copies worker_firstboot.sh to the FAT boot partition
+Optionally writes immersionmonitor-wifi.env to the FAT boot partition
 Adds a systemd.run first-boot hook to cmdline.txt
 Enables SSH by creating the bootfs ssh marker file
 ```
@@ -128,12 +141,17 @@ Enables SSH by creating the bootfs ssh marker file
 The worker Pi:
 
 ```text
-waits for network
+creates a Wi-Fi connection if immersionmonitor-wifi.env exists
+installs a second-stage provisioning service
+removes the early first-boot hook from cmdline.txt
+reboots into normal boot
+waits for network-online.target
+checks DNS and GitHub access
 runs apt update
 installs python3, stress-ng, curl, ca-certificates
 copies worker_agent.py to /opt/immersionmonitor
 installs bench-worker-agent.service
-removes the first-boot hook from cmdline.txt
+disables the provisioning service
 reboots
 starts the worker agent automatically after reboot
 ```
@@ -144,7 +162,7 @@ Log file on the SD boot partition:
 /boot/firmware/immersionmonitor-firstboot.log
 ```
 
-If provisioning fails, the first-boot hook is left in place so the worker retries on the next boot.
+If provisioning fails, the second-stage provisioning service is left enabled so the worker retries on the next boot.
 
 ## After installation
 

--- a/scripts/prepare_worker_bootfs.ps1
+++ b/scripts/prepare_worker_bootfs.ps1
@@ -4,7 +4,10 @@ param(
 
     [string]$Branch = "main",
     [string]$RepoOwner = "ramorimdias",
-    [string]$RepoName = "immersionmonitor"
+    [string]$RepoName = "immersionmonitor",
+    [string]$WifiSsid = "",
+    [string]$WifiPassword = "",
+    [string]$WifiCountry = "FR"
 )
 
 $ErrorActionPreference = "Stop"
@@ -17,6 +20,7 @@ $BootRoot = $BootDrive.TrimEnd("\") + "\"
 $CmdlinePath = Join-Path $BootRoot "cmdline.txt"
 $FirstBootPath = Join-Path $BootRoot "worker_firstboot.sh"
 $SshPath = Join-Path $BootRoot "ssh"
+$WifiEnvPath = Join-Path $BootRoot "immersionmonitor-wifi.env"
 
 if (-not (Test-Path $CmdlinePath)) {
     throw "cmdline.txt not found on $BootRoot. Select the Raspberry Pi OS bootfs drive, not the Windows recovery prompt."
@@ -27,6 +31,21 @@ $FirstBootUrl = "$RawBase/scripts/worker_firstboot.sh"
 
 Write-Host "Downloading first-boot script..."
 Invoke-WebRequest -Uri $FirstBootUrl -OutFile $FirstBootPath -UseBasicParsing
+
+if ($WifiSsid -ne "") {
+    if ($WifiPassword -eq "") {
+        throw "WifiPassword is required when WifiSsid is provided."
+    }
+    Write-Host "Writing Wi-Fi configuration for first boot..."
+    $SsidB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($WifiSsid))
+    $PasswordB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($WifiPassword))
+    $WifiEnv = @"
+WIFI_SSID_B64=$SsidB64
+WIFI_PASSWORD_B64=$PasswordB64
+WIFI_COUNTRY=$WifiCountry
+"@
+    Set-Content -Path $WifiEnvPath -Value $WifiEnv -Encoding ascii
+}
 
 Write-Host "Adding first-boot hook to cmdline.txt..."
 $Cmdline = Get-Content -Raw -Path $CmdlinePath
@@ -50,7 +69,7 @@ Write-Host "Worker SD card prepared successfully."
 Write-Host "Next steps:"
 Write-Host "1. Eject the SD card safely from Windows."
 Write-Host "2. Insert it into the worker Pi."
-Write-Host "3. Connect Ethernet to a network with internet access for first boot."
+Write-Host "3. Connect Ethernet or make sure the configured Wi-Fi is available."
 Write-Host "4. Power on the Pi and wait until it installs and reboots."
 Write-Host "5. Move it to the bench switch."
 Write-Host ""

--- a/scripts/prepare_worker_bootfs.ps1
+++ b/scripts/prepare_worker_bootfs.ps1
@@ -1,0 +1,57 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$BootDrive,
+
+    [string]$Branch = "main",
+    [string]$RepoOwner = "ramorimdias",
+    [string]$RepoName = "immersionmonitor"
+)
+
+$ErrorActionPreference = "Stop"
+
+if ($BootDrive -notmatch "^[A-Za-z]:\\?$") {
+    throw "BootDrive must be a Windows drive letter, for example E:"
+}
+
+$BootRoot = $BootDrive.TrimEnd("\") + "\"
+$CmdlinePath = Join-Path $BootRoot "cmdline.txt"
+$FirstBootPath = Join-Path $BootRoot "worker_firstboot.sh"
+$SshPath = Join-Path $BootRoot "ssh"
+
+if (-not (Test-Path $CmdlinePath)) {
+    throw "cmdline.txt not found on $BootRoot. Select the Raspberry Pi OS bootfs drive, not the Windows recovery prompt."
+}
+
+$RawBase = "https://raw.githubusercontent.com/$RepoOwner/$RepoName/$Branch"
+$FirstBootUrl = "$RawBase/scripts/worker_firstboot.sh"
+
+Write-Host "Downloading first-boot script..."
+Invoke-WebRequest -Uri $FirstBootUrl -OutFile $FirstBootPath -UseBasicParsing
+
+Write-Host "Adding first-boot hook to cmdline.txt..."
+$Cmdline = Get-Content -Raw -Path $CmdlinePath
+$Cmdline = $Cmdline -replace "`r", "" -replace "`n", ""
+$Hook = "systemd.run=/boot/firmware/worker_firstboot.sh systemd.run_success_action=reboot systemd.unit=kernel-command-line.target"
+
+if ($Cmdline -notmatch "systemd\.run=/boot/firmware/worker_firstboot\.sh") {
+    $Cmdline = ($Cmdline.Trim() + " " + $Hook).Trim()
+    Set-Content -Path $CmdlinePath -Value $Cmdline -NoNewline -Encoding ascii
+} else {
+    Write-Host "First-boot hook already present."
+}
+
+if (-not (Test-Path $SshPath)) {
+    Write-Host "Creating ssh marker file..."
+    New-Item -Path $SshPath -ItemType File | Out-Null
+}
+
+Write-Host ""
+Write-Host "Worker SD card prepared successfully."
+Write-Host "Next steps:"
+Write-Host "1. Eject the SD card safely from Windows."
+Write-Host "2. Insert it into the worker Pi."
+Write-Host "3. Connect Ethernet to a network with internet access for first boot."
+Write-Host "4. Power on the Pi and wait until it installs and reboots."
+Write-Host "5. Move it to the bench switch."
+Write-Host ""
+Write-Host "First-boot log will be written on the Pi at /boot/firmware/immersionmonitor-firstboot.log"

--- a/scripts/prepare_worker_bootfs.sh
+++ b/scripts/prepare_worker_bootfs.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BOOTFS="${1:-}"
+BRANCH="${IMMERSIONMONITOR_BRANCH:-main}"
+REPO_OWNER="${IMMERSIONMONITOR_REPO_OWNER:-ramorimdias}"
+REPO_NAME="${IMMERSIONMONITOR_REPO_NAME:-immersionmonitor}"
+RAW_BASE="${IMMERSIONMONITOR_RAW_BASE:-https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/${BRANCH}}"
+FIRSTBOOT_NAME="worker_firstboot.sh"
+
+usage() {
+  cat <<EOF
+Usage:
+  $0 /path/to/bootfs
+
+Example:
+  $0 /media/$USER/bootfs
+
+This prepares a freshly flashed Raspberry Pi OS SD card so a worker Pi installs
+immersionmonitor automatically on first boot. The boot partition must be mounted.
+EOF
+}
+
+if [[ -z "${BOOTFS}" || "${BOOTFS}" == "-h" || "${BOOTFS}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ ! -d "${BOOTFS}" ]]; then
+  echo "ERROR: bootfs path does not exist: ${BOOTFS}" >&2
+  exit 1
+fi
+
+CMDLINE="${BOOTFS}/cmdline.txt"
+if [[ ! -f "${CMDLINE}" ]]; then
+  echo "ERROR: ${CMDLINE} not found. Did you select the FAT boot partition?" >&2
+  exit 1
+fi
+
+if command -v curl >/dev/null 2>&1; then
+  curl -fsSL "${RAW_BASE}/scripts/${FIRSTBOOT_NAME}" -o "${BOOTFS}/${FIRSTBOOT_NAME}"
+else
+  echo "ERROR: curl is required." >&2
+  exit 1
+fi
+chmod 755 "${BOOTFS}/${FIRSTBOOT_NAME}"
+
+HOOK="systemd.run=/boot/firmware/${FIRSTBOOT_NAME} systemd.run_success_action=reboot systemd.unit=kernel-command-line.target"
+
+if grep -q "systemd.run=/boot/firmware/${FIRSTBOOT_NAME}" "${CMDLINE}"; then
+  echo "First-boot hook already present in cmdline.txt."
+else
+  tmp="$(mktemp)"
+  tr -d '\n' < "${CMDLINE}" > "${tmp}"
+  printf ' %s\n' "${HOOK}" >> "${tmp}"
+  cp "${tmp}" "${CMDLINE}"
+  rm -f "${tmp}"
+fi
+
+if [[ ! -e "${BOOTFS}/ssh" && ! -e "${BOOTFS}/ssh.txt" ]]; then
+  touch "${BOOTFS}/ssh"
+fi
+
+sync
+
+echo "Worker SD card prepared."
+echo "Next steps:"
+echo "1. Eject the SD card safely."
+echo "2. Insert it into the worker Pi."
+echo "3. Connect Ethernet to a network with internet access for first boot."
+echo "4. Power on the Pi and wait until it installs, cleans the first-boot hook, and reboots."
+echo "5. Move it to the bench switch."

--- a/scripts/run_readable_monitor_auto.sh
+++ b/scripts/run_readable_monitor_auto.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DIR="${IMMERSIONMONITOR_REPO_DIR:-/opt/immersionmonitor}"
+AGENT_PORT="${BENCH_AGENT_PORT:-8765}"
+PYTHON="${PYTHON:-python3}"
+
+choose_cidr() {
+  local ips ip prefix
+  ips="$(hostname -I 2>/dev/null || true)"
+
+  # Prefer the two known bench/company ranges seen during setup.
+  for ip in ${ips}; do
+    case "${ip}" in
+      192.168.50.*)
+        echo "192.168.50.0/24"
+        return 0
+        ;;
+      10.50.0.*)
+        echo "10.50.0.0/24"
+        return 0
+        ;;
+    esac
+  done
+
+  # Generic private IPv4 fallback: scan the /24 of the first private address.
+  for ip in ${ips}; do
+    case "${ip}" in
+      10.*.*.*|192.168.*.*|172.1[6-9].*.*|172.2[0-9].*.*|172.3[0-1].*.*)
+        prefix="${ip%.*}"
+        echo "${prefix}.0/24"
+        return 0
+        ;;
+    esac
+  done
+
+  # Last resort: original default bench network.
+  echo "10.50.0.0/24"
+}
+
+CIDR="${DISCOVERY_CIDR:-$(choose_cidr)}"
+
+echo "Starting readable monitor"
+echo "Discovery CIDR: ${CIDR}"
+echo "Worker agent port: ${AGENT_PORT}"
+
+cd "${APP_DIR}"
+exec "${PYTHON}" readable_monitor.py --discovery-cidr "${CIDR}" --agent-port "${AGENT_PORT}" "$@"

--- a/scripts/worker_firstboot.sh
+++ b/scripts/worker_firstboot.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOG_FILE="/boot/firmware/immersionmonitor-firstboot.log"
+BOOT_CMDLINE="/boot/firmware/cmdline.txt"
+INSTALL_DIR="${IMMERSIONMONITOR_INSTALL_DIR:-/opt/immersionmonitor}"
+REPO_OWNER="${IMMERSIONMONITOR_REPO_OWNER:-ramorimdias}"
+REPO_NAME="${IMMERSIONMONITOR_REPO_NAME:-immersionmonitor}"
+BRANCH="${IMMERSIONMONITOR_BRANCH:-main}"
+BASE_URL="${IMMERSIONMONITOR_RAW_BASE:-https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/${BRANCH}}"
+AGENT_PORT="${BENCH_AGENT_PORT:-8765}"
+SERVICE_NAME="bench-worker-agent.service"
+
+exec > >(tee -a "${LOG_FILE}") 2>&1
+
+echo "===== immersionmonitor worker first boot: $(date --iso-8601=seconds) ====="
+
+cleanup_cmdline() {
+  if [[ -f "${BOOT_CMDLINE}" ]]; then
+    sed -i \
+      -e 's# *systemd.run=/boot/firmware/worker_firstboot.sh##g' \
+      -e 's# *systemd.run_success_action=reboot##g' \
+      -e 's# *systemd.unit=kernel-command-line.target##g' \
+      "${BOOT_CMDLINE}"
+  fi
+}
+
+wait_for_network() {
+  echo "Waiting for network..."
+  for _ in $(seq 1 90); do
+    if getent hosts raw.githubusercontent.com >/dev/null 2>&1; then
+      echo "Network is ready."
+      return 0
+    fi
+    sleep 2
+  done
+  echo "ERROR: Network is not ready. Connect worker to a network with internet access and reboot."
+  return 1
+}
+
+wait_for_apt() {
+  echo "Waiting for apt locks..."
+  for _ in $(seq 1 60); do
+    if ! fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 && \
+       ! fuser /var/lib/dpkg/lock >/dev/null 2>&1 && \
+       ! fuser /var/cache/apt/archives/lock >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+  echo "APT lock wait timed out; continuing anyway."
+}
+
+install_worker() {
+  wait_for_network
+  wait_for_apt
+
+  echo "Updating package index..."
+  apt-get update
+
+  echo "Installing dependencies..."
+  DEBIAN_FRONTEND=noninteractive apt-get install -y python3 stress-ng curl ca-certificates
+
+  echo "Installing worker agent in ${INSTALL_DIR}..."
+  mkdir -p "${INSTALL_DIR}"
+  curl -fsSL "${BASE_URL}/worker_agent.py" -o "${INSTALL_DIR}/worker_agent.py"
+  chmod 755 "${INSTALL_DIR}/worker_agent.py"
+
+  echo "Installing worker systemd service..."
+  tmp_service="$(mktemp)"
+  curl -fsSL "${BASE_URL}/systemd/${SERVICE_NAME}" -o "${tmp_service}"
+  sed -i "s/--port 8765/--port ${AGENT_PORT}/" "${tmp_service}"
+  install -m 0644 "${tmp_service}" "/etc/systemd/system/${SERVICE_NAME}"
+  rm -f "${tmp_service}"
+
+  systemctl daemon-reload
+  systemctl enable "${SERVICE_NAME}"
+
+  echo "Installation complete. Worker agent will start after reboot."
+}
+
+main() {
+  if install_worker; then
+    cleanup_cmdline
+    sync
+    echo "First-boot provisioning succeeded. Rebooting."
+    reboot
+  else
+    echo "First-boot provisioning failed. Leaving cmdline hook in place so it retries on next boot."
+    exit 1
+  fi
+}
+
+main "$@"

--- a/scripts/worker_firstboot.sh
+++ b/scripts/worker_firstboot.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 LOG_FILE="/boot/firmware/immersionmonitor-firstboot.log"
 BOOT_CMDLINE="/boot/firmware/cmdline.txt"
+WIFI_ENV="/boot/firmware/immersionmonitor-wifi.env"
 INSTALL_DIR="${IMMERSIONMONITOR_INSTALL_DIR:-/opt/immersionmonitor}"
 REPO_OWNER="${IMMERSIONMONITOR_REPO_OWNER:-ramorimdias}"
 REPO_NAME="${IMMERSIONMONITOR_REPO_NAME:-immersionmonitor}"
@@ -24,6 +25,63 @@ cleanup_cmdline() {
       -e 's# *systemd.unit=kernel-command-line.target##g' \
       "${BOOT_CMDLINE}"
   fi
+}
+
+configure_wifi() {
+  if [[ ! -f "${WIFI_ENV}" ]]; then
+    echo "No Wi-Fi config file found; skipping Wi-Fi setup."
+    return 0
+  fi
+
+  # shellcheck disable=SC1090
+  source "${WIFI_ENV}"
+  if [[ -z "${WIFI_SSID_B64:-}" || -z "${WIFI_PASSWORD_B64:-}" ]]; then
+    echo "Wi-Fi config file exists but SSID or password is missing."
+    return 0
+  fi
+
+  ssid="$(printf '%s' "${WIFI_SSID_B64}" | base64 -d)"
+  password="$(printf '%s' "${WIFI_PASSWORD_B64}" | base64 -d)"
+  country="${WIFI_COUNTRY:-FR}"
+
+  echo "Configuring Wi-Fi SSID: ${ssid}"
+  mkdir -p /etc/NetworkManager/system-connections
+  cat > /etc/NetworkManager/system-connections/immersionmonitor-worker-wifi.nmconnection <<EOF
+[connection]
+id=immersionmonitor-worker-wifi
+type=wifi
+interface-name=wlan0
+autoconnect=true
+
+[wifi]
+mode=infrastructure
+ssid=${ssid}
+
+[wifi-security]
+key-mgmt=wpa-psk
+psk=${password}
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=auto
+addr-gen-mode=default
+EOF
+  chmod 600 /etc/NetworkManager/system-connections/immersionmonitor-worker-wifi.nmconnection
+
+  # Fallback for images still using wpa_supplicant.
+  mkdir -p /etc/wpa_supplicant
+  cat > /etc/wpa_supplicant/wpa_supplicant.conf <<EOF
+country=${country}
+ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
+update_config=1
+network={
+    ssid="${ssid}"
+    psk="${password}"
+}
+EOF
+  chmod 600 /etc/wpa_supplicant/wpa_supplicant.conf
 }
 
 install_second_stage_service() {
@@ -121,6 +179,7 @@ main() {
       fi
       ;;
     *)
+      configure_wifi
       install_second_stage_service
       cleanup_cmdline
       sync

--- a/scripts/worker_firstboot.sh
+++ b/scripts/worker_firstboot.sh
@@ -10,10 +10,11 @@ BRANCH="${IMMERSIONMONITOR_BRANCH:-main}"
 BASE_URL="${IMMERSIONMONITOR_RAW_BASE:-https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/${BRANCH}}"
 AGENT_PORT="${BENCH_AGENT_PORT:-8765}"
 SERVICE_NAME="bench-worker-agent.service"
+PROVISION_SERVICE="immersionmonitor-worker-provision.service"
 
 exec > >(tee -a "${LOG_FILE}") 2>&1
 
-echo "===== immersionmonitor worker first boot: $(date --iso-8601=seconds) ====="
+echo "===== immersionmonitor worker provisioning: $(date --iso-8601=seconds) ====="
 
 cleanup_cmdline() {
   if [[ -f "${BOOT_CMDLINE}" ]]; then
@@ -25,16 +26,39 @@ cleanup_cmdline() {
   fi
 }
 
+install_second_stage_service() {
+  echo "Installing second-stage provisioning service."
+  cat > "/etc/systemd/system/${PROVISION_SERVICE}" <<EOF
+[Unit]
+Description=Provision immersionmonitor worker after network is online
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/boot/firmware/worker_firstboot.sh --install
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+  systemctl daemon-reload
+  systemctl enable "${PROVISION_SERVICE}"
+}
+
 wait_for_network() {
-  echo "Waiting for network..."
-  for _ in $(seq 1 90); do
-    if getent hosts raw.githubusercontent.com >/dev/null 2>&1; then
+  echo "Waiting for usable network: DHCP + DNS + GitHub access..."
+  for _ in $(seq 1 120); do
+    ip -4 addr show scope global || true
+    if getent hosts raw.githubusercontent.com >/dev/null 2>&1 && \
+       curl -fsI --connect-timeout 5 --max-time 10 "${BASE_URL}/worker_agent.py" >/dev/null 2>&1; then
       echo "Network is ready."
       return 0
     fi
-    sleep 2
+    sleep 3
   done
-  echo "ERROR: Network is not ready. Connect worker to a network with internet access and reboot."
+  echo "ERROR: Network is not ready or GitHub is blocked."
+  echo "Check DHCP, DNS, proxy, firewall, and whether raw.githubusercontent.com is allowed."
   return 1
 }
 
@@ -76,19 +100,34 @@ install_worker() {
   systemctl daemon-reload
   systemctl enable "${SERVICE_NAME}"
 
+  echo "Disabling provisioning service."
+  systemctl disable "${PROVISION_SERVICE}" || true
+  rm -f "/etc/systemd/system/${PROVISION_SERVICE}"
+  systemctl daemon-reload
+
   echo "Installation complete. Worker agent will start after reboot."
 }
 
 main() {
-  if install_worker; then
-    cleanup_cmdline
-    sync
-    echo "First-boot provisioning succeeded. Rebooting."
-    reboot
-  else
-    echo "First-boot provisioning failed. Leaving cmdline hook in place so it retries on next boot."
-    exit 1
-  fi
+  case "${1:-}" in
+    --install)
+      if install_worker; then
+        sync
+        echo "Second-stage provisioning succeeded. Rebooting."
+        reboot
+      else
+        echo "Second-stage provisioning failed. It will retry on next normal boot."
+        exit 1
+      fi
+      ;;
+    *)
+      install_second_stage_service
+      cleanup_cmdline
+      sync
+      echo "First-stage setup complete. Rebooting into normal boot so networking can start."
+      reboot
+      ;;
+  esac
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

Adds a first-boot provisioning path for worker Raspberry Pis so they can install themselves without connecting a screen or keyboard.

## New files

- `scripts/worker_firstboot.sh`
- `scripts/prepare_worker_bootfs.sh`
- `WORKER_FIRSTBOOT.md`

## Workflow

1. Flash Raspberry Pi OS Lite 64-bit.
2. Mount the SD card boot partition.
3. Run the preparation script on the boot partition.
4. Insert the SD card into the worker Pi.
5. Connect Ethernet to a network with internet access.
6. Power on the worker.
7. The worker installs dependencies, installs `worker_agent.py`, enables `bench-worker-agent.service`, removes the first-boot hook, and reboots.
8. Move the worker to the bench switch.

## Prepare SD card after merge

```bash
curl -fsSL https://raw.githubusercontent.com/ramorimdias/immersionmonitor/main/scripts/prepare_worker_bootfs.sh -o /tmp/prepare_worker_bootfs.sh
bash /tmp/prepare_worker_bootfs.sh /media/$USER/bootfs
```

## Test before merge

```bash
curl -fsSL https://raw.githubusercontent.com/ramorimdias/immersionmonitor/worker-firstboot-provisioning/scripts/prepare_worker_bootfs.sh -o /tmp/prepare_worker_bootfs.sh
IMMERSIONMONITOR_BRANCH=worker-firstboot-provisioning bash /tmp/prepare_worker_bootfs.sh /media/$USER/bootfs
```

## Notes

- This requires internet access on first boot because the worker runs `apt-get install` and downloads repo files.
- After provisioning, the worker can run on the isolated bench network.
- This is not a fully offline custom OS image. A fully offline image would need to embed `stress-ng`, Python, the worker agent, and the service files directly in the image.