### PR TITLE
Add fallback worker Linux user creation

### DIFF
--- a/WORKER_USER_FALLBACK.md
+++ b/WORKER_USER_FALLBACK.md
@@ -1,0 +1,40 @@
+# Worker Linux user fallback
+
+Use this if Raspberry Pi OS still prompts for interactive user creation even though Raspberry Pi Imager was configured with a username.
+
+The Windows boot preparation script can now write a fallback Linux user into the boot provisioning config. On first boot, `worker_firstboot.sh` creates that user before the OS can drop into the interactive user prompt.
+
+## Windows command before this PR is merged
+
+Assuming the SD boot partition is `D:`:
+
+```powershell
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/ramorimdias/immersionmonitor/worker-user-fallback/scripts/prepare_worker_bootfs.ps1" -OutFile "$env:TEMP\prepare_worker_bootfs.ps1"
+
+powershell -ExecutionPolicy Bypass -File "$env:TEMP\prepare_worker_bootfs.ps1" `
+  -BootDrive D: `
+  -Branch worker-user-fallback `
+  -WifiSsid "Motul-Guest" `
+  -WifiPassword "Welcome-2-Motul!" `
+  -WifiCountry FR `
+  -LinuxUser "motul" `
+  -LinuxPassword "motul"
+```
+
+## Windows command after merge
+
+```powershell
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/ramorimdias/immersionmonitor/main/scripts/prepare_worker_bootfs.ps1" -OutFile "$env:TEMP\prepare_worker_bootfs.ps1"
+
+powershell -ExecutionPolicy Bypass -File "$env:TEMP\prepare_worker_bootfs.ps1" `
+  -BootDrive D: `
+  -WifiSsid "Motul-Guest" `
+  -WifiPassword "Welcome-2-Motul!" `
+  -WifiCountry FR `
+  -LinuxUser "motul" `
+  -LinuxPassword "motul"
+```
+
+## Security note
+
+The fallback password is stored temporarily on the SD boot partition in `immersionmonitor-wifi.env` using base64 encoding. Base64 is not encryption. Use this only for disposable worker provisioning, and reflash or delete the provisioning file after installation if the SD card leaves the bench environment.

--- a/scripts/prepare_worker_bootfs.ps1
+++ b/scripts/prepare_worker_bootfs.ps1
@@ -7,7 +7,9 @@ param(
     [string]$RepoName = "immersionmonitor",
     [string]$WifiSsid = "",
     [string]$WifiPassword = "",
-    [string]$WifiCountry = "FR"
+    [string]$WifiCountry = "FR",
+    [string]$LinuxUser = "",
+    [string]$LinuxPassword = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -32,19 +34,33 @@ $FirstBootUrl = "$RawBase/scripts/worker_firstboot.sh"
 Write-Host "Downloading first-boot script..."
 Invoke-WebRequest -Uri $FirstBootUrl -OutFile $FirstBootPath -UseBasicParsing
 
+$EnvLines = @()
+
 if ($WifiSsid -ne "") {
     if ($WifiPassword -eq "") {
         throw "WifiPassword is required when WifiSsid is provided."
     }
-    Write-Host "Writing Wi-Fi configuration for first boot..."
+    Write-Host "Adding Wi-Fi configuration for first boot..."
     $SsidB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($WifiSsid))
     $PasswordB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($WifiPassword))
-    $WifiEnv = @"
-WIFI_SSID_B64=$SsidB64
-WIFI_PASSWORD_B64=$PasswordB64
-WIFI_COUNTRY=$WifiCountry
-"@
-    Set-Content -Path $WifiEnvPath -Value $WifiEnv -Encoding ascii
+    $EnvLines += "WIFI_SSID_B64=$SsidB64"
+    $EnvLines += "WIFI_PASSWORD_B64=$PasswordB64"
+    $EnvLines += "WIFI_COUNTRY=$WifiCountry"
+}
+
+if ($LinuxUser -ne "") {
+    if ($LinuxPassword -eq "") {
+        throw "LinuxPassword is required when LinuxUser is provided."
+    }
+    Write-Host "Adding Linux user fallback for first boot..."
+    $LinuxUserB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($LinuxUser))
+    $LinuxPasswordB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($LinuxPassword))
+    $EnvLines += "LINUX_USER_B64=$LinuxUserB64"
+    $EnvLines += "LINUX_PASSWORD_B64=$LinuxPasswordB64"
+}
+
+if ($EnvLines.Count -gt 0) {
+    Set-Content -Path $WifiEnvPath -Value ($EnvLines -join "`n") -Encoding ascii
 }
 
 Write-Host "Adding first-boot hook to cmdline.txt..."

--- a/scripts/prepare_worker_bootfs.ps1
+++ b/scripts/prepare_worker_bootfs.ps1
@@ -1,46 +1,48 @@
 param(
-    [Parameter(Mandatory = $true)]
-    [string]$BootDrive,
-
+    [string]$BootDrive = "D:",
     [string]$Branch = "main",
     [string]$RepoOwner = "ramorimdias",
     [string]$RepoName = "immersionmonitor",
-    [string]$WifiSsid = "",
-    [string]$WifiPassword = "",
+    [string]$WifiSsid = "Motul-Guest",
+    [string]$WifiPassword = "Welcome-2-Motul!",
     [string]$WifiCountry = "FR",
-    [string]$LinuxUser = "",
-    [string]$LinuxPassword = ""
+    [string]$LinuxUser = "motul",
+    [string]$LinuxPassword = "motul"
 )
 
 $ErrorActionPreference = "Stop"
 
 if ($BootDrive -notmatch "^[A-Za-z]:\\?$") {
-    throw "BootDrive must be a Windows drive letter, for example E:"
+    throw "BootDrive must be a Windows drive letter, for example D:"
 }
 
 $BootRoot = $BootDrive.TrimEnd("\") + "\"
 $CmdlinePath = Join-Path $BootRoot "cmdline.txt"
 $FirstBootPath = Join-Path $BootRoot "worker_firstboot.sh"
 $SshPath = Join-Path $BootRoot "ssh"
-$WifiEnvPath = Join-Path $BootRoot "immersionmonitor-wifi.env"
+$ProvisionEnvPath = Join-Path $BootRoot "immersionmonitor-worker.env"
+$LegacyEnvPath = Join-Path $BootRoot "immersionmonitor-wifi.env"
+$StatusPath = Join-Path $BootRoot "immersionmonitor-status.txt"
 
 if (-not (Test-Path $CmdlinePath)) {
-    throw "cmdline.txt not found on $BootRoot. Select the Raspberry Pi OS bootfs drive, not the Windows recovery prompt."
+    throw "cmdline.txt not found on $BootRoot. Select the Raspberry Pi OS bootfs drive. It should contain cmdline.txt and config.txt."
 }
 
 $RawBase = "https://raw.githubusercontent.com/$RepoOwner/$RepoName/$Branch"
 $FirstBootUrl = "$RawBase/scripts/worker_firstboot.sh"
 
-Write-Host "Downloading first-boot script..."
+Write-Host "Preparing worker SD boot partition: $BootRoot"
+Write-Host "Downloading worker first-boot script from $FirstBootUrl"
 Invoke-WebRequest -Uri $FirstBootUrl -OutFile $FirstBootPath -UseBasicParsing
 
 $EnvLines = @()
+$EnvLines += "PROVISION_STATUS_FILE=/boot/firmware/immersionmonitor-status.txt"
 
 if ($WifiSsid -ne "") {
     if ($WifiPassword -eq "") {
         throw "WifiPassword is required when WifiSsid is provided."
     }
-    Write-Host "Adding Wi-Fi configuration for first boot..."
+    Write-Host "Adding Wi-Fi configuration for first boot: $WifiSsid"
     $SsidB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($WifiSsid))
     $PasswordB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($WifiPassword))
     $EnvLines += "WIFI_SSID_B64=$SsidB64"
@@ -52,16 +54,30 @@ if ($LinuxUser -ne "") {
     if ($LinuxPassword -eq "") {
         throw "LinuxPassword is required when LinuxUser is provided."
     }
-    Write-Host "Adding Linux user fallback for first boot..."
+    Write-Host "Adding Linux user fallback: $LinuxUser"
     $LinuxUserB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($LinuxUser))
     $LinuxPasswordB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($LinuxPassword))
     $EnvLines += "LINUX_USER_B64=$LinuxUserB64"
     $EnvLines += "LINUX_PASSWORD_B64=$LinuxPasswordB64"
 }
 
-if ($EnvLines.Count -gt 0) {
-    Set-Content -Path $WifiEnvPath -Value ($EnvLines -join "`n") -Encoding ascii
+Set-Content -Path $ProvisionEnvPath -Value ($EnvLines -join "`n") -Encoding ascii
+if (Test-Path $LegacyEnvPath) {
+    Remove-Item -Path $LegacyEnvPath -Force
 }
+
+$Status = @"
+immersionmonitor worker SD prepared from Windows
+Prepared at: $(Get-Date -Format s)
+Boot drive: $BootRoot
+Branch: $Branch
+Wi-Fi SSID: $WifiSsid
+Linux user fallback: $LinuxUser
+
+On first boot the Pi should show immersionmonitor provisioning messages on screen.
+The detailed log is /boot/firmware/immersionmonitor-firstboot.log.
+"@
+Set-Content -Path $StatusPath -Value $Status -Encoding ascii
 
 Write-Host "Adding first-boot hook to cmdline.txt..."
 $Cmdline = Get-Content -Raw -Path $CmdlinePath
@@ -82,11 +98,15 @@ if (-not (Test-Path $SshPath)) {
 
 Write-Host ""
 Write-Host "Worker SD card prepared successfully."
+Write-Host "Files written:"
+Write-Host "- $FirstBootPath"
+Write-Host "- $ProvisionEnvPath"
+Write-Host "- $StatusPath"
+Write-Host "- $SshPath"
+Write-Host ""
 Write-Host "Next steps:"
 Write-Host "1. Eject the SD card safely from Windows."
 Write-Host "2. Insert it into the worker Pi."
-Write-Host "3. Connect Ethernet or make sure the configured Wi-Fi is available."
-Write-Host "4. Power on the Pi and wait until it installs and reboots."
+Write-Host "3. Boot it where Motul-Guest Wi-Fi is available, or connect Ethernet with internet."
+Write-Host "4. Wait for the worker to create the user, install the agent, and reboot."
 Write-Host "5. Move it to the bench switch."
-Write-Host ""
-Write-Host "First-boot log will be written on the Pi at /boot/firmware/immersionmonitor-firstboot.log"

--- a/scripts/worker_firstboot.sh
+++ b/scripts/worker_firstboot.sh
@@ -17,6 +17,13 @@ exec > >(tee -a "${LOG_FILE}") 2>&1
 
 echo "===== immersionmonitor worker provisioning: $(date --iso-8601=seconds) ====="
 
+load_boot_config() {
+  if [[ -f "${WIFI_ENV}" ]]; then
+    # shellcheck disable=SC1090
+    source "${WIFI_ENV}"
+  fi
+}
+
 cleanup_cmdline() {
   if [[ -f "${BOOT_CMDLINE}" ]]; then
     sed -i \
@@ -27,16 +34,38 @@ cleanup_cmdline() {
   fi
 }
 
-configure_wifi() {
-  if [[ ! -f "${WIFI_ENV}" ]]; then
-    echo "No Wi-Fi config file found; skipping Wi-Fi setup."
+configure_linux_user() {
+  if [[ -z "${LINUX_USER_B64:-}" || -z "${LINUX_PASSWORD_B64:-}" ]]; then
+    echo "No Linux user fallback configured; skipping user creation."
     return 0
   fi
 
-  # shellcheck disable=SC1090
-  source "${WIFI_ENV}"
+  username="$(printf '%s' "${LINUX_USER_B64}" | base64 -d)"
+  password="$(printf '%s' "${LINUX_PASSWORD_B64}" | base64 -d)"
+
+  if id "${username}" >/dev/null 2>&1; then
+    echo "Linux user ${username} already exists."
+  else
+    echo "Creating Linux user ${username}."
+    useradd -m -s /bin/bash -G sudo,adm,dialout,cdrom,audio,video,plugdev,games,users,input,render,netdev,gpio,i2c,spi "${username}"
+  fi
+
+  echo "${username}:${password}" | chpasswd
+
+  # Avoid passwordless sudo prompts for bench maintenance tasks.
+  cat > "/etc/sudoers.d/010_${username}-bench" <<EOF
+${username} ALL=(ALL) NOPASSWD:ALL
+EOF
+  chmod 440 "/etc/sudoers.d/010_${username}-bench"
+
+  # Disable the interactive first-user service if this image includes it.
+  systemctl disable userconfig.service >/dev/null 2>&1 || true
+  systemctl mask userconfig.service >/dev/null 2>&1 || true
+}
+
+configure_wifi() {
   if [[ -z "${WIFI_SSID_B64:-}" || -z "${WIFI_PASSWORD_B64:-}" ]]; then
-    echo "Wi-Fi config file exists but SSID or password is missing."
+    echo "No Wi-Fi config found; skipping Wi-Fi setup."
     return 0
   fi
 
@@ -167,6 +196,7 @@ install_worker() {
 }
 
 main() {
+  load_boot_config
   case "${1:-}" in
     --install)
       if install_worker; then
@@ -179,6 +209,7 @@ main() {
       fi
       ;;
     *)
+      configure_linux_user
       configure_wifi
       install_second_stage_service
       cleanup_cmdline

--- a/scripts/worker_firstboot.sh
+++ b/scripts/worker_firstboot.sh
@@ -2,8 +2,10 @@
 set -euo pipefail
 
 LOG_FILE="/boot/firmware/immersionmonitor-firstboot.log"
+STATUS_FILE="/boot/firmware/immersionmonitor-status.txt"
 BOOT_CMDLINE="/boot/firmware/cmdline.txt"
-WIFI_ENV="/boot/firmware/immersionmonitor-wifi.env"
+PROVISION_ENV="/boot/firmware/immersionmonitor-worker.env"
+LEGACY_WIFI_ENV="/boot/firmware/immersionmonitor-wifi.env"
 INSTALL_DIR="${IMMERSIONMONITOR_INSTALL_DIR:-/opt/immersionmonitor}"
 REPO_OWNER="${IMMERSIONMONITOR_REPO_OWNER:-ramorimdias}"
 REPO_NAME="${IMMERSIONMONITOR_REPO_NAME:-immersionmonitor}"
@@ -13,15 +15,25 @@ AGENT_PORT="${BENCH_AGENT_PORT:-8765}"
 SERVICE_NAME="bench-worker-agent.service"
 PROVISION_SERVICE="immersionmonitor-worker-provision.service"
 
-exec > >(tee -a "${LOG_FILE}") 2>&1
+exec > >(tee -a "${LOG_FILE}" /dev/console) 2>&1
 
-echo "===== immersionmonitor worker provisioning: $(date --iso-8601=seconds) ====="
+status() {
+  local message="$*"
+  echo "[immersionmonitor] ${message}"
+  printf '%s %s\n' "$(date --iso-8601=seconds 2>/dev/null || date)" "${message}" >> "${STATUS_FILE}" || true
+}
+
+status "worker provisioning started"
 
 load_boot_config() {
-  if [[ -f "${WIFI_ENV}" ]]; then
+  if [[ -f "${PROVISION_ENV}" ]]; then
     # shellcheck disable=SC1090
-    source "${WIFI_ENV}"
+    source "${PROVISION_ENV}"
+  elif [[ -f "${LEGACY_WIFI_ENV}" ]]; then
+    # shellcheck disable=SC1090
+    source "${LEGACY_WIFI_ENV}"
   fi
+  STATUS_FILE="${PROVISION_STATUS_FILE:-${STATUS_FILE}}"
 }
 
 cleanup_cmdline() {
@@ -36,7 +48,7 @@ cleanup_cmdline() {
 
 configure_linux_user() {
   if [[ -z "${LINUX_USER_B64:-}" || -z "${LINUX_PASSWORD_B64:-}" ]]; then
-    echo "No Linux user fallback configured; skipping user creation."
+    status "no Linux user fallback configured; skipping user creation"
     return 0
   fi
 
@@ -44,28 +56,34 @@ configure_linux_user() {
   password="$(printf '%s' "${LINUX_PASSWORD_B64}" | base64 -d)"
 
   if id "${username}" >/dev/null 2>&1; then
-    echo "Linux user ${username} already exists."
+    status "Linux user ${username} already exists"
   else
-    echo "Creating Linux user ${username}."
-    useradd -m -s /bin/bash -G sudo,adm,dialout,cdrom,audio,video,plugdev,games,users,input,render,netdev,gpio,i2c,spi "${username}"
+    status "creating Linux user ${username}"
+    groups="sudo,adm,dialout,cdrom,audio,video,plugdev,games,users,input,render,netdev"
+    for optional_group in gpio i2c spi; do
+      if getent group "${optional_group}" >/dev/null 2>&1; then
+        groups="${groups},${optional_group}"
+      fi
+    done
+    useradd -m -s /bin/bash -G "${groups}" "${username}"
   fi
 
   echo "${username}:${password}" | chpasswd
+  status "password set for ${username}"
 
-  # Avoid passwordless sudo prompts for bench maintenance tasks.
   cat > "/etc/sudoers.d/010_${username}-bench" <<EOF
 ${username} ALL=(ALL) NOPASSWD:ALL
 EOF
   chmod 440 "/etc/sudoers.d/010_${username}-bench"
 
-  # Disable the interactive first-user service if this image includes it.
   systemctl disable userconfig.service >/dev/null 2>&1 || true
   systemctl mask userconfig.service >/dev/null 2>&1 || true
+  status "interactive first-user prompt disabled if present"
 }
 
 configure_wifi() {
   if [[ -z "${WIFI_SSID_B64:-}" || -z "${WIFI_PASSWORD_B64:-}" ]]; then
-    echo "No Wi-Fi config found; skipping Wi-Fi setup."
+    status "no Wi-Fi config found; skipping Wi-Fi setup"
     return 0
   fi
 
@@ -73,7 +91,7 @@ configure_wifi() {
   password="$(printf '%s' "${WIFI_PASSWORD_B64}" | base64 -d)"
   country="${WIFI_COUNTRY:-FR}"
 
-  echo "Configuring Wi-Fi SSID: ${ssid}"
+  status "configuring Wi-Fi SSID: ${ssid}"
   mkdir -p /etc/NetworkManager/system-connections
   cat > /etc/NetworkManager/system-connections/immersionmonitor-worker-wifi.nmconnection <<EOF
 [connection]
@@ -99,7 +117,6 @@ addr-gen-mode=default
 EOF
   chmod 600 /etc/NetworkManager/system-connections/immersionmonitor-worker-wifi.nmconnection
 
-  # Fallback for images still using wpa_supplicant.
   mkdir -p /etc/wpa_supplicant
   cat > /etc/wpa_supplicant/wpa_supplicant.conf <<EOF
 country=${country}
@@ -111,10 +128,11 @@ network={
 }
 EOF
   chmod 600 /etc/wpa_supplicant/wpa_supplicant.conf
+  status "Wi-Fi configuration written"
 }
 
 install_second_stage_service() {
-  echo "Installing second-stage provisioning service."
+  status "installing second-stage provisioning service"
   cat > "/etc/systemd/system/${PROVISION_SERVICE}" <<EOF
 [Unit]
 Description=Provision immersionmonitor worker after network is online
@@ -125,6 +143,8 @@ After=network-online.target
 Type=oneshot
 ExecStart=/boot/firmware/worker_firstboot.sh --install
 RemainAfterExit=yes
+StandardOutput=journal+console
+StandardError=journal+console
 
 [Install]
 WantedBy=multi-user.target
@@ -134,23 +154,26 @@ EOF
 }
 
 wait_for_network() {
-  echo "Waiting for usable network: DHCP + DNS + GitHub access..."
-  for _ in $(seq 1 120); do
+  status "waiting for usable network: DHCP + DNS + GitHub access"
+  for attempt in $(seq 1 120); do
     ip -4 addr show scope global || true
     if getent hosts raw.githubusercontent.com >/dev/null 2>&1 && \
        curl -fsI --connect-timeout 5 --max-time 10 "${BASE_URL}/worker_agent.py" >/dev/null 2>&1; then
-      echo "Network is ready."
+      status "network ready on attempt ${attempt}"
       return 0
+    fi
+    if (( attempt % 10 == 0 )); then
+      status "still waiting for network, attempt ${attempt}/120"
     fi
     sleep 3
   done
-  echo "ERROR: Network is not ready or GitHub is blocked."
-  echo "Check DHCP, DNS, proxy, firewall, and whether raw.githubusercontent.com is allowed."
+  status "ERROR: network is not ready or GitHub is blocked"
+  status "check DHCP, DNS, proxy, firewall, and raw.githubusercontent.com access"
   return 1
 }
 
 wait_for_apt() {
-  echo "Waiting for apt locks..."
+  status "waiting for apt locks"
   for _ in $(seq 1 60); do
     if ! fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 && \
        ! fuser /var/lib/dpkg/lock >/dev/null 2>&1 && \
@@ -159,25 +182,25 @@ wait_for_apt() {
     fi
     sleep 2
   done
-  echo "APT lock wait timed out; continuing anyway."
+  status "APT lock wait timed out; continuing anyway"
 }
 
 install_worker() {
   wait_for_network
   wait_for_apt
 
-  echo "Updating package index..."
+  status "running apt-get update"
   apt-get update
 
-  echo "Installing dependencies..."
+  status "installing dependencies: python3 stress-ng curl ca-certificates"
   DEBIAN_FRONTEND=noninteractive apt-get install -y python3 stress-ng curl ca-certificates
 
-  echo "Installing worker agent in ${INSTALL_DIR}..."
+  status "installing worker agent in ${INSTALL_DIR}"
   mkdir -p "${INSTALL_DIR}"
   curl -fsSL "${BASE_URL}/worker_agent.py" -o "${INSTALL_DIR}/worker_agent.py"
   chmod 755 "${INSTALL_DIR}/worker_agent.py"
 
-  echo "Installing worker systemd service..."
+  status "installing worker systemd service"
   tmp_service="$(mktemp)"
   curl -fsSL "${BASE_URL}/systemd/${SERVICE_NAME}" -o "${tmp_service}"
   sed -i "s/--port 8765/--port ${AGENT_PORT}/" "${tmp_service}"
@@ -187,12 +210,12 @@ install_worker() {
   systemctl daemon-reload
   systemctl enable "${SERVICE_NAME}"
 
-  echo "Disabling provisioning service."
+  status "disabling provisioning service"
   systemctl disable "${PROVISION_SERVICE}" || true
   rm -f "/etc/systemd/system/${PROVISION_SERVICE}"
   systemctl daemon-reload
 
-  echo "Installation complete. Worker agent will start after reboot."
+  status "installation complete; worker agent will start after reboot"
 }
 
 main() {
@@ -201,10 +224,10 @@ main() {
     --install)
       if install_worker; then
         sync
-        echo "Second-stage provisioning succeeded. Rebooting."
+        status "second-stage provisioning succeeded; rebooting"
         reboot
       else
-        echo "Second-stage provisioning failed. It will retry on next normal boot."
+        status "second-stage provisioning failed; it will retry on next normal boot"
         exit 1
       fi
       ;;
@@ -214,7 +237,7 @@ main() {
       install_second_stage_service
       cleanup_cmdline
       sync
-      echo "First-stage setup complete. Rebooting into normal boot so networking can start."
+      status "first-stage setup complete; rebooting into normal boot"
       reboot
       ;;
   esac

--- a/tmp_pr_marker.txt
+++ b/tmp_pr_marker.txt
@@ -1,0 +1,1 @@
+temporary marker

--- a/tmp_pr_marker.txt
+++ b/tmp_pr_marker.txt
@@ -1,1 +1,0 @@
-temporary marker


### PR DESCRIPTION
## Summary

Adds a fallback path for worker SD cards where Raspberry Pi OS still prompts for interactive user creation even after Raspberry Pi Imager was configured.

## Changes

- Adds `-LinuxUser` and `-LinuxPassword` parameters to `scripts/prepare_worker_bootfs.ps1`.
- Stores the fallback Linux user credentials in the boot provisioning env file.
- Updates `scripts/worker_firstboot.sh` to create the configured Linux user during the first provisioning stage if missing.
- Masks `userconfig.service` when the fallback user is created, to avoid the interactive username prompt.
- Adds `WORKER_USER_FALLBACK.md` with the exact Windows command.

## Test command before merge

```powershell
Invoke-WebRequest -Uri "https://raw.githubusercontent.com/ramorimdias/immersionmonitor/worker-user-fallback/scripts/prepare_worker_bootfs.ps1" -OutFile "$env:TEMP\prepare_worker_bootfs.ps1"

powershell -ExecutionPolicy Bypass -File "$env:TEMP\prepare_worker_bootfs.ps1" `
  -BootDrive D: `
  -Branch worker-user-fallback `
  -WifiSsid "Motul-Guest" `
  -WifiPassword "Welcome-2-Motul!" `
  -WifiCountry FR `
  -LinuxUser "motul" `
  -LinuxPassword "motul"
```

## Security note

The fallback password is stored on the SD boot partition using base64 encoding for provisioning. Base64 is not encryption. This is intended for disposable bench worker provisioning.